### PR TITLE
Add JSON output for alias lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "log",
  "owo-colors",
  "serde",
+ "serde_json",
  "temp-env",
  "tempfile",
  "toml",
@@ -380,6 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jiff"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +644,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -912,3 +932,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ indexmap = { version = "2.12.1", features = ["serde"] }
 log = "0.4.28"
 owo-colors = "4.2.3"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 toml = { version = "0.9.8", features = ["preserve_order"] }
 toml_edit = "0.23.7"
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ll = { command = "ls -la", enabled = true }
 - `aliasmgr add alias <name> <command> [--group <group>] [--disabled] [--global]` (explicit form)
 - `aliasmgr add group <name> [--disabled]`
 - `aliasmgr move <name> [group]`
-- `aliasmgr list [<pattern>] [--group [group]] [--enabled] [--disabled] [--global]`
+- `aliasmgr list [<pattern>] [--group [group]] [--enabled] [--disabled] [--global] [--format <human|json>]`
 - `aliasmgr remove <name>` (removes the matching alias or group; prompts if both exist)
 - `aliasmgr remove alias <name>` (explicit form)
 - `aliasmgr remove group <name> [--reassign [--enable-reassigned | --disable-reassigned]]`
@@ -76,6 +76,7 @@ For more details, use the `-h` or `--help` flags.
 Notes:
 - Alias names cannot be empty or contain whitespace or `=`.
 - Global aliases (`--global`) only work on zsh; they are skipped on other shells.
+- `list --format json` emits an array of aliases with `name`, `command`, `group`, `enabled`, and `global` fields. Ungrouped aliases have a `null` group.
 
 ## Sync Behavior
 - Each initialized terminal tracks the alias names and effective catalog revision that it last applied.

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -1,8 +1,9 @@
 use owo_colors::OwoColorize;
+use serde::Serialize;
 
 use super::shell::ShellType;
 use crate::catalog::types::AliasCatalog;
-use crate::cli::list::ListCommand;
+use crate::cli::list::{ListCommand, OutputFormat};
 use crate::core::list::{get_aliases_from_single_group, get_all_aliases_grouped};
 use crate::core::{Failure, Outcome};
 
@@ -118,29 +119,82 @@ fn retain_aliases(catalog: &AliasCatalog, aliases: &mut Vec<String>, cmd: &ListC
     }
 }
 
+fn select_aliases(
+    catalog: &AliasCatalog,
+    cmd: &ListCommand,
+    shell: &ShellType,
+) -> Result<indexmap::IndexMap<Option<String>, Vec<String>>, Failure> {
+    let mut groups = if let Some(group) = &cmd.group {
+        let group_id = group.clone();
+        let aliases = get_aliases_from_single_group(catalog, group_id.as_deref(), shell)?;
+        indexmap::IndexMap::from([(group_id, aliases)])
+    } else {
+        get_all_aliases_grouped(catalog, shell)
+    };
+
+    for aliases in groups.values_mut() {
+        retain_aliases(catalog, aliases, cmd);
+    }
+    groups.retain(|_, aliases| !aliases.is_empty());
+    Ok(groups)
+}
+
+#[derive(Serialize)]
+struct JsonAlias<'a> {
+    name: &'a str,
+    command: &'a str,
+    group: Option<&'a str>,
+    enabled: bool,
+    global: bool,
+}
+
+fn format_json(
+    catalog: &AliasCatalog,
+    groups: &indexmap::IndexMap<Option<String>, Vec<String>>,
+) -> String {
+    let aliases = groups
+        .values()
+        .flatten()
+        .map(|name| {
+            let alias = &catalog.aliases[name];
+            JsonAlias {
+                name,
+                command: &alias.command,
+                group: alias.group.as_deref(),
+                enabled: alias.enabled,
+                global: alias.global,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    serde_json::to_string_pretty(&aliases).expect("alias list is JSON serializable") + "\n"
+}
+
+fn format_human(
+    catalog: &AliasCatalog,
+    groups: &indexmap::IndexMap<Option<String>, Vec<String>>,
+    focused_group: bool,
+) -> Result<String, Failure> {
+    let mut content = String::new();
+    for (group_id, aliases) in groups {
+        if focused_group {
+            content += &format_group_and_aliases_single_group(catalog, group_id, aliases)?;
+        } else {
+            content += &format_group_and_aliases(catalog, group_id, aliases)?;
+        }
+    }
+    Ok(content)
+}
+
 fn format_list(
     catalog: &AliasCatalog,
     cmd: &ListCommand,
     shell: &ShellType,
 ) -> Result<String, Failure> {
-    if let Some(group) = &cmd.group {
-        let group_id = group.clone();
-        let mut aliases = get_aliases_from_single_group(catalog, group_id.as_deref(), shell)?;
-        retain_aliases(catalog, &mut aliases, cmd);
-        if aliases.is_empty() {
-            return Ok(String::new());
-        }
-        format_group_and_aliases_single_group(catalog, &group_id, &aliases)
-    } else {
-        let mut content = String::new();
-        for (group_id, mut aliases) in get_all_aliases_grouped(catalog, shell) {
-            retain_aliases(catalog, &mut aliases, cmd);
-            if aliases.is_empty() {
-                continue;
-            }
-            content += &format_group_and_aliases(catalog, &group_id, &aliases)?;
-        }
-        Ok(content)
+    let groups = select_aliases(catalog, cmd, shell)?;
+    match cmd.format {
+        OutputFormat::Human => format_human(catalog, &groups, cmd.group.is_some()),
+        OutputFormat::Json => Ok(format_json(catalog, &groups)),
     }
 }
 
@@ -270,6 +324,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
 
         let output = format_list(&catalog, &cmd, &ShellType::Bash).unwrap();
@@ -288,6 +343,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
 
         let output = format_list(&catalog, &cmd, &ShellType::Zsh).unwrap();
@@ -306,6 +362,7 @@ mod tests {
             enabled: true,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let disabled = ListCommand {
             pattern: None,
@@ -313,6 +370,7 @@ mod tests {
             enabled: false,
             disabled: true,
             global: false,
+            format: OutputFormat::Human,
         };
 
         let enabled_output = format_list(&catalog, &enabled, &ShellType::Bash).unwrap();
@@ -335,6 +393,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: true,
+            format: OutputFormat::Human,
         };
 
         assert_eq!(format_list(&catalog, &cmd, &ShellType::Bash).unwrap(), "");
@@ -346,6 +405,103 @@ mod tests {
     }
 
     #[test]
+    fn json_lists_ungrouped_and_grouped_aliases() {
+        let catalog = create_test_catalog();
+        let cmd = ListCommand {
+            pattern: None,
+            group: None,
+            enabled: false,
+            disabled: false,
+            global: false,
+            format: OutputFormat::Json,
+        };
+
+        let output = format_list(&catalog, &cmd, &ShellType::Bash).unwrap();
+        let aliases: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(
+            aliases,
+            serde_json::json!([
+                {
+                    "name": "test",
+                    "command": "echo test",
+                    "group": null,
+                    "enabled": true,
+                    "global": false
+                },
+                {
+                    "name": "build",
+                    "command": "cargo build",
+                    "group": "dev",
+                    "enabled": true,
+                    "global": false
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn json_respects_pattern_group_and_status_filters() {
+        let catalog = create_filtered_catalog();
+        let cmd = ListCommand {
+            pattern: Some("d*".to_string()),
+            group: Some(Some("ops".to_string())),
+            enabled: false,
+            disabled: true,
+            global: false,
+            format: OutputFormat::Json,
+        };
+
+        let output = format_list(&catalog, &cmd, &ShellType::Zsh).unwrap();
+        let aliases: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(
+            aliases,
+            serde_json::json!([{
+                "name": "deploy",
+                "command": "deploy",
+                "group": "ops",
+                "enabled": false,
+                "global": false
+            }])
+        );
+    }
+
+    #[test]
+    fn json_only_includes_global_aliases_for_zsh() {
+        let catalog = create_filtered_catalog();
+        let cmd = ListCommand {
+            pattern: None,
+            group: None,
+            enabled: false,
+            disabled: false,
+            global: true,
+            format: OutputFormat::Json,
+        };
+
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                &format_list(&catalog, &cmd, &ShellType::Bash).unwrap()
+            )
+            .unwrap(),
+            serde_json::json!([])
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                &format_list(&catalog, &cmd, &ShellType::Zsh).unwrap()
+            )
+            .unwrap(),
+            serde_json::json!([{
+                "name": "glob",
+                "command": "*.rs",
+                "group": "zsh",
+                "enabled": true,
+                "global": true
+            }])
+        );
+    }
+
+    #[test]
     fn no_matches_or_empty_focused_group_produce_no_output() {
         let catalog = create_filtered_catalog();
         let no_matches = ListCommand {
@@ -354,6 +510,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let empty_focused_group = ListCommand {
             pattern: Some("missing*".to_string()),
@@ -361,6 +518,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
 
         assert_eq!(
@@ -383,6 +541,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -397,6 +556,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert_matches!(result, Err(Failure::GroupDoesNotExist));
@@ -411,6 +571,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -425,6 +586,7 @@ mod tests {
             enabled: true,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -439,6 +601,7 @@ mod tests {
             enabled: false,
             disabled: true,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -453,6 +616,7 @@ mod tests {
             enabled: true,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -467,6 +631,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -481,6 +646,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: true,
+            format: OutputFormat::Human,
         };
         let result = handle_list(&catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
@@ -563,6 +729,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         retain_aliases(&catalog, &mut aliases, &cmd);
         assert!(!aliases.is_empty());
@@ -582,6 +749,7 @@ mod tests {
             enabled: true,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         retain_aliases(&catalog, &mut aliases, &cmd);
         assert!(!aliases.is_empty());
@@ -601,6 +769,7 @@ mod tests {
             enabled: false,
             disabled: true,
             global: false,
+            format: OutputFormat::Human,
         };
         retain_aliases(&catalog, &mut aliases, &cmd);
         assert!(!aliases.is_empty());
@@ -619,6 +788,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: false,
+            format: OutputFormat::Human,
         };
         retain_aliases(&catalog, &mut aliases, &cmd);
         assert!(!aliases.is_empty());
@@ -638,6 +808,7 @@ mod tests {
             enabled: false,
             disabled: false,
             global: true,
+            format: OutputFormat::Human,
         };
         retain_aliases(&catalog, &mut aliases, &cmd);
         assert!(!aliases.is_empty());

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,4 +1,11 @@
-use clap::{ArgGroup, Args};
+use clap::{ArgGroup, Args, ValueEnum};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+}
 
 #[derive(Args)]
 #[command(
@@ -27,4 +34,8 @@ pub struct ListCommand {
     /// Show only global aliases
     #[arg(long)]
     pub global: bool,
+
+    /// Select the output format
+    #[arg(long, value_enum, default_value = "human")]
+    pub format: OutputFormat,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -362,6 +362,27 @@ mod tests {
     }
 
     #[test]
+    fn parses_list_output_format_and_defaults_to_human() {
+        let default = Cli::try_parse_from(["aliasmgr", "list"]).unwrap();
+        assert!(matches!(
+            default.command,
+            Commands::List(ListCommand {
+                format: list::OutputFormat::Human,
+                ..
+            })
+        ));
+
+        let json = Cli::try_parse_from(["aliasmgr", "list", "--format", "json"]).unwrap();
+        assert!(matches!(
+            json.command,
+            Commands::List(ListCommand {
+                format: list::OutputFormat::Json,
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn parses_internal_conditional_shell_sync() {
         let cli = Cli::try_parse_from(["aliasmgr", "shell-sync", "--if-changed"])
             .expect("internal shell sync should parse");


### PR DESCRIPTION
## Summary

- add `aliasmgr list --format json` while keeping colored human output as the default
- share alias selection and filtering between human and JSON renderers
- document the JSON schema and cover grouped, ungrouped, filtered, and shell-specific global aliases

## Acceptance criteria

- [x] `list` emits machine-readable JSON with `name`, `command`, `group`, `enabled`, and `global`
- [x] pattern, group, enabled, disabled, and global filters share the existing selection path
- [x] global aliases are omitted for incompatible shells
- [x] the default human-readable output remains unchanged

## Validation

- `cargo build --verbose`
- `cargo test --verbose` (215 unit tests and 6 shell integration tests passed)
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info`

Closes #2
