### PR TITLE
Add bulk enable and disable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ ll = { command = "ls -la", enabled = true }
 - `aliasmgr enable <name>` (enables the matching alias or group; prompts if both exist)
 - `aliasmgr enable alias <name>` (explicit form)
 - `aliasmgr enable group <name>`
+- `aliasmgr enable all`
 - `aliasmgr disable <name>` (disables the matching alias or group; prompts if both exist)
 - `aliasmgr disable alias <name>` (explicit form)
 - `aliasmgr disable group <name>`
+- `aliasmgr disable all`
 
 For more details, use the `-h` or `--help` flags.
 

--- a/src/app/disable.rs
+++ b/src/app/disable.rs
@@ -1,5 +1,5 @@
 use crate::catalog::types::AliasCatalog;
-use crate::core::disable::{disable_alias, disable_group};
+use crate::core::disable::{disable_alias, disable_all, disable_group};
 use crate::core::{Failure, Outcome};
 
 use crate::cli::disable::{DisableCommand, DisableTarget};
@@ -28,6 +28,7 @@ pub fn handle_disable(
     match cmd.target {
         Some(DisableTarget::Alias(args)) => disable_alias(catalog, &args.name),
         Some(DisableTarget::Group(args)) => disable_group(catalog, &args.name, shell),
+        Some(DisableTarget::All) => disable_all(catalog),
         None => handle_disable_shorthand(
             catalog,
             cmd.name
@@ -115,6 +116,24 @@ mod tests {
 
         assert!(alias_result.is_ok());
         assert!(group_result.is_ok());
+        assert!(!catalog.aliases["ll"].enabled);
+        assert!(!catalog.groups["tools"]);
+    }
+
+    #[test]
+    fn disables_all_aliases_and_groups() {
+        let mut catalog = sample_catalog();
+
+        let result = handle_disable(
+            &mut catalog,
+            DisableCommand {
+                target: Some(DisableTarget::All),
+                name: None,
+            },
+            &ShellType::Bash,
+        );
+
+        assert_eq!(result, Ok(Outcome::CatalogChanged));
         assert!(!catalog.aliases["ll"].enabled);
         assert!(!catalog.groups["tools"]);
     }

--- a/src/app/disable.rs
+++ b/src/app/disable.rs
@@ -5,6 +5,7 @@ use crate::core::{Failure, Outcome};
 use crate::cli::disable::{DisableCommand, DisableTarget};
 use crate::cli::interaction::prompt_alias_or_group;
 
+use super::CommandOutcome;
 use super::resource::{ResourceType, resolve_resource_type};
 use super::shell::ShellType;
 
@@ -24,11 +25,21 @@ pub fn handle_disable(
     catalog: &mut AliasCatalog,
     cmd: DisableCommand,
     shell: &ShellType,
-) -> Result<Outcome, Failure> {
+) -> Result<CommandOutcome, Failure> {
     match cmd.target {
-        Some(DisableTarget::Alias(args)) => disable_alias(catalog, &args.name),
-        Some(DisableTarget::Group(args)) => disable_group(catalog, &args.name, shell),
-        Some(DisableTarget::All) => disable_all(catalog),
+        Some(DisableTarget::Alias(args)) => {
+            disable_alias(catalog, &args.name).map(CommandOutcome::from)
+        }
+        Some(DisableTarget::Group(args)) => {
+            disable_group(catalog, &args.name, shell).map(CommandOutcome::from)
+        }
+        Some(DisableTarget::All) => disable_all(catalog).map(|outcome| {
+            let message = match outcome {
+                Outcome::CatalogChanged => "All aliases and groups are now disabled.",
+                Outcome::NoChanges => "All aliases and groups are already disabled.",
+            };
+            CommandOutcome::with_message(outcome, message)
+        }),
         None => handle_disable_shorthand(
             catalog,
             cmd.name
@@ -36,7 +47,8 @@ pub fn handle_disable(
                 .expect("clap requires a name when no subcommand is used"),
             shell,
             |name| prompt_alias_or_group(name, "disabled"),
-        ),
+        )
+        .map(CommandOutcome::from),
     }
 }
 
@@ -133,7 +145,13 @@ mod tests {
             &ShellType::Bash,
         );
 
-        assert_eq!(result, Ok(Outcome::CatalogChanged));
+        assert_eq!(
+            result,
+            Ok(CommandOutcome::with_message(
+                Outcome::CatalogChanged,
+                "All aliases and groups are now disabled."
+            ))
+        );
         assert!(!catalog.aliases["ll"].enabled);
         assert!(!catalog.groups["tools"]);
     }

--- a/src/app/enable.rs
+++ b/src/app/enable.rs
@@ -1,5 +1,5 @@
 use crate::catalog::types::AliasCatalog;
-use crate::core::enable::{enable_alias, enable_group};
+use crate::core::enable::{enable_alias, enable_all, enable_group};
 use crate::core::{Failure, Outcome};
 
 use crate::cli::enable::{EnableCommand, EnableTarget};
@@ -28,6 +28,7 @@ pub fn handle_enable(
     match cmd.target {
         Some(EnableTarget::Alias(args)) => enable_alias(catalog, &args.name),
         Some(EnableTarget::Group(args)) => enable_group(catalog, &args.name, shell),
+        Some(EnableTarget::All) => enable_all(catalog),
         None => handle_enable_shorthand(
             catalog,
             cmd.name
@@ -115,6 +116,24 @@ mod tests {
 
         assert!(alias_result.is_ok());
         assert!(group_result.is_ok());
+        assert!(catalog.aliases["ll"].enabled);
+        assert!(catalog.groups["tools"]);
+    }
+
+    #[test]
+    fn enables_all_aliases_and_groups() {
+        let mut catalog = sample_catalog();
+
+        let result = handle_enable(
+            &mut catalog,
+            EnableCommand {
+                target: Some(EnableTarget::All),
+                name: None,
+            },
+            &ShellType::Bash,
+        );
+
+        assert_eq!(result, Ok(Outcome::CatalogChanged));
         assert!(catalog.aliases["ll"].enabled);
         assert!(catalog.groups["tools"]);
     }

--- a/src/app/enable.rs
+++ b/src/app/enable.rs
@@ -5,6 +5,7 @@ use crate::core::{Failure, Outcome};
 use crate::cli::enable::{EnableCommand, EnableTarget};
 use crate::cli::interaction::prompt_alias_or_group;
 
+use super::CommandOutcome;
 use super::resource::{ResourceType, resolve_resource_type};
 use super::shell::ShellType;
 
@@ -24,11 +25,21 @@ pub fn handle_enable(
     catalog: &mut AliasCatalog,
     cmd: EnableCommand,
     shell: &ShellType,
-) -> Result<Outcome, Failure> {
+) -> Result<CommandOutcome, Failure> {
     match cmd.target {
-        Some(EnableTarget::Alias(args)) => enable_alias(catalog, &args.name),
-        Some(EnableTarget::Group(args)) => enable_group(catalog, &args.name, shell),
-        Some(EnableTarget::All) => enable_all(catalog),
+        Some(EnableTarget::Alias(args)) => {
+            enable_alias(catalog, &args.name).map(CommandOutcome::from)
+        }
+        Some(EnableTarget::Group(args)) => {
+            enable_group(catalog, &args.name, shell).map(CommandOutcome::from)
+        }
+        Some(EnableTarget::All) => enable_all(catalog).map(|outcome| {
+            let message = match outcome {
+                Outcome::CatalogChanged => "All aliases and groups are now enabled.",
+                Outcome::NoChanges => "All aliases and groups are already enabled.",
+            };
+            CommandOutcome::with_message(outcome, message)
+        }),
         None => handle_enable_shorthand(
             catalog,
             cmd.name
@@ -36,7 +47,8 @@ pub fn handle_enable(
                 .expect("clap requires a name when no subcommand is used"),
             shell,
             |name| prompt_alias_or_group(name, "enabled"),
-        ),
+        )
+        .map(CommandOutcome::from),
     }
 }
 
@@ -133,7 +145,13 @@ mod tests {
             &ShellType::Bash,
         );
 
-        assert_eq!(result, Ok(Outcome::CatalogChanged));
+        assert_eq!(
+            result,
+            Ok(CommandOutcome::with_message(
+                Outcome::CatalogChanged,
+                "All aliases and groups are now enabled."
+            ))
+        );
         assert!(catalog.aliases["ll"].enabled);
         assert!(catalog.groups["tools"]);
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,3 +12,29 @@ pub(crate) mod resource;
 pub(crate) mod shell;
 pub(crate) mod sort;
 pub(crate) mod sync;
+
+use crate::core::Outcome;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct CommandOutcome {
+    pub outcome: Outcome,
+    pub message: Option<&'static str>,
+}
+
+impl CommandOutcome {
+    pub fn with_message(outcome: Outcome, message: &'static str) -> Self {
+        Self {
+            outcome,
+            message: Some(message),
+        }
+    }
+}
+
+impl From<Outcome> for CommandOutcome {
+    fn from(outcome: Outcome) -> Self {
+        Self {
+            outcome,
+            message: None,
+        }
+    }
+}

--- a/src/cli/disable.rs
+++ b/src/cli/disable.rs
@@ -26,6 +26,9 @@ pub enum DisableTarget {
     /// Disable a group
     #[command(visible_alias = "g")]
     Group(DisableArgs),
+
+    /// Disable all aliases and groups
+    All,
 }
 
 #[derive(Args)]

--- a/src/cli/enable.rs
+++ b/src/cli/enable.rs
@@ -26,6 +26,9 @@ pub enum EnableTarget {
     /// Enable a group
     #[command(visible_alias = "g")]
     Group(EnableArgs),
+
+    /// Enable all aliases and groups
+    All,
 }
 
 #[derive(Args)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -302,6 +302,26 @@ mod tests {
                 ..
             }) if args.name == "tools"
         ));
+
+        let all =
+            Cli::try_parse_from(["aliasmgr", "enable", "all"]).expect("enable all should parse");
+        assert!(matches!(
+            all.command,
+            Commands::Enable(EnableCommand {
+                target: Some(EnableTarget::All),
+                ..
+            })
+        ));
+
+        let reserved = Cli::try_parse_from(["aliasmgr", "enable", "alias", "all"])
+            .expect("an alias named all should remain addressable explicitly");
+        assert!(matches!(
+            reserved.command,
+            Commands::Enable(EnableCommand {
+                target: Some(EnableTarget::Alias(args)),
+                ..
+            }) if args.name == "all"
+        ));
     }
 
     #[test]
@@ -324,6 +344,26 @@ mod tests {
                 target: Some(DisableTarget::Alias(args)),
                 ..
             }) if args.name == "group"
+        ));
+
+        let all =
+            Cli::try_parse_from(["aliasmgr", "disable", "all"]).expect("disable all should parse");
+        assert!(matches!(
+            all.command,
+            Commands::Disable(DisableCommand {
+                target: Some(DisableTarget::All),
+                ..
+            })
+        ));
+
+        let reserved = Cli::try_parse_from(["aliasmgr", "disable", "alias", "all"])
+            .expect("an alias named all should remain addressable explicitly");
+        assert!(matches!(
+            reserved.command,
+            Commands::Disable(DisableCommand {
+                target: Some(DisableTarget::Alias(args)),
+                ..
+            }) if args.name == "all"
         ));
     }
 

--- a/src/core/disable.rs
+++ b/src/core/disable.rs
@@ -42,6 +42,24 @@ pub fn disable_group(
     Ok(Outcome::CatalogChanged)
 }
 
+pub fn disable_all(catalog: &mut AliasCatalog) -> Result<Outcome, Failure> {
+    let aliases_changed = catalog.aliases.values().any(|alias| alias.enabled);
+    let groups_changed = catalog.groups.values().any(|enabled| *enabled);
+
+    if !aliases_changed && !groups_changed {
+        return Ok(Outcome::NoChanges);
+    }
+
+    for alias in catalog.aliases.values_mut() {
+        alias.enabled = false;
+    }
+    for enabled in catalog.groups.values_mut() {
+        *enabled = false;
+    }
+
+    Ok(Outcome::CatalogChanged)
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
@@ -149,5 +167,28 @@ mod test {
         let result = disable_group(&mut catalog, "enabled_group", &ShellType::Bash);
         assert!(!catalog.groups["enabled_group"]);
         assert_eq!(result.unwrap(), Outcome::CatalogChanged);
+    }
+
+    #[test]
+    fn disable_all_updates_mixed_alias_and_group_state() {
+        let mut catalog = sample_catalog();
+
+        let result = disable_all(&mut catalog);
+
+        assert_eq!(result, Ok(Outcome::CatalogChanged));
+        assert!(catalog.aliases.values().all(|alias| !alias.enabled));
+        assert!(catalog.groups.values().all(|enabled| !*enabled));
+    }
+
+    #[test]
+    fn disable_all_is_idempotent_and_handles_empty_catalogs() {
+        let mut catalog = AliasCatalog::new();
+        assert_eq!(disable_all(&mut catalog), Ok(Outcome::NoChanges));
+
+        catalog
+            .aliases
+            .insert("alias".into(), Alias::new("cmd".into(), None, true, false));
+        assert_eq!(disable_all(&mut catalog), Ok(Outcome::CatalogChanged));
+        assert_eq!(disable_all(&mut catalog), Ok(Outcome::NoChanges));
     }
 }

--- a/src/core/enable.rs
+++ b/src/core/enable.rs
@@ -42,6 +42,24 @@ pub fn enable_group(
     Ok(Outcome::CatalogChanged)
 }
 
+pub fn enable_all(catalog: &mut AliasCatalog) -> Result<Outcome, Failure> {
+    let aliases_changed = catalog.aliases.values().any(|alias| !alias.enabled);
+    let groups_changed = catalog.groups.values().any(|enabled| !enabled);
+
+    if !aliases_changed && !groups_changed {
+        return Ok(Outcome::NoChanges);
+    }
+
+    for alias in catalog.aliases.values_mut() {
+        alias.enabled = true;
+    }
+    for enabled in catalog.groups.values_mut() {
+        *enabled = true;
+    }
+
+    Ok(Outcome::CatalogChanged)
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
@@ -150,5 +168,28 @@ mod test {
         assert!(result.is_ok());
         assert!(catalog.groups["disabled_group"]);
         assert_matches!(result.unwrap(), Outcome::CatalogChanged);
+    }
+
+    #[test]
+    fn enable_all_updates_mixed_alias_and_group_state() {
+        let mut catalog = sample_catalog();
+
+        let result = enable_all(&mut catalog);
+
+        assert_eq!(result, Ok(Outcome::CatalogChanged));
+        assert!(catalog.aliases.values().all(|alias| alias.enabled));
+        assert!(catalog.groups.values().all(|enabled| *enabled));
+    }
+
+    #[test]
+    fn enable_all_is_idempotent_and_handles_empty_catalogs() {
+        let mut catalog = AliasCatalog::new();
+        assert_eq!(enable_all(&mut catalog), Ok(Outcome::NoChanges));
+
+        catalog
+            .aliases
+            .insert("alias".into(), Alias::new("cmd".into(), None, false, false));
+        assert_eq!(enable_all(&mut catalog), Ok(Outcome::CatalogChanged));
+        assert_eq!(enable_all(&mut catalog), Ok(Outcome::NoChanges));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,6 @@ mod core;
 
 use clap::Parser;
 
-use cli::disable::DisableTarget;
-use cli::enable::EnableTarget;
 use cli::{Cli, Commands};
 
 use catalog::io::{catalog_path as resolve_catalog_path, load_catalog, save_catalog};
@@ -16,6 +14,7 @@ use catalog::io::{catalog_path as resolve_catalog_path, load_catalog, save_catal
 use catalog::types::AliasCatalog;
 use core::Outcome;
 
+use app::CommandOutcome;
 use app::add::handle_add;
 use app::disable::handle_disable;
 use app::edit::handle_edit;
@@ -37,13 +36,6 @@ use log::{LevelFilter, debug};
 fn main() {
     let cli = Cli::parse();
     let quiet = cli.quiet;
-    let bulk_action = match &cli.command {
-        Commands::Enable(cmd) if matches!(cmd.target, Some(EnableTarget::All)) => Some("enabled"),
-        Commands::Disable(cmd) if matches!(cmd.target, Some(DisableTarget::All)) => {
-            Some("disabled")
-        }
-        _ => None,
-    };
 
     // Determine log level based on CLI flags
     let level = if cli.quiet {
@@ -82,47 +74,46 @@ fn main() {
 
     let result = match cli.command {
         // Add new alias or group
-        Commands::Add(cmd) => handle_add(&mut catalog, cmd, &shell),
-        Commands::Remove(cmd) => handle_remove(&mut catalog, cmd, &shell),
-        Commands::Move(cmd) => handle_move(&mut catalog, cmd),
-        Commands::List(cmd) => handle_list(&catalog, cmd, &shell),
-        Commands::Rename(cmd) => handle_rename(&mut catalog, cmd),
-        Commands::Edit(cmd) => handle_edit(&mut catalog, cmd),
-        Commands::Sort(cmd) => handle_sort(&mut catalog, cmd),
+        Commands::Add(cmd) => handle_add(&mut catalog, cmd, &shell).map(CommandOutcome::from),
+        Commands::Remove(cmd) => handle_remove(&mut catalog, cmd, &shell).map(CommandOutcome::from),
+        Commands::Move(cmd) => handle_move(&mut catalog, cmd).map(CommandOutcome::from),
+        Commands::List(cmd) => handle_list(&catalog, cmd, &shell).map(CommandOutcome::from),
+        Commands::Rename(cmd) => handle_rename(&mut catalog, cmd).map(CommandOutcome::from),
+        Commands::Edit(cmd) => handle_edit(&mut catalog, cmd).map(CommandOutcome::from),
+        Commands::Sort(cmd) => handle_sort(&mut catalog, cmd).map(CommandOutcome::from),
         Commands::Enable(cmd) => handle_enable(&mut catalog, cmd, &shell),
         Commands::Disable(cmd) => handle_disable(&mut catalog, cmd, &shell),
-        Commands::Sync(cmd) => handle_sync(cmd),
+        Commands::Sync(cmd) => handle_sync(cmd).map(CommandOutcome::from),
         Commands::ShellSync(cmd) => {
             print!("{}", handle_shell_sync(&catalog, &shell, cmd));
-            Ok(Outcome::NoChanges)
+            Ok(CommandOutcome::from(Outcome::NoChanges))
         }
         Commands::Init(cmd) => {
             let content = handle_init(cmd);
             debug!("Generated init script content");
             println!("{}", content);
-            Ok(Outcome::NoChanges)
+            Ok(CommandOutcome::from(Outcome::NoChanges))
         }
     };
 
     match result {
-        Ok(Outcome::NoChanges) => {
-            debug!("No changes made to catalog or shell.");
-            if let Some(action) = bulk_action
+        Ok(CommandOutcome { outcome, message }) => {
+            match outcome {
+                Outcome::NoChanges => debug!("No changes made to catalog or shell."),
+                Outcome::CatalogChanged => {
+                    if save_catalog(&catalog, &resolve_catalog_path(catalog_path.as_ref())).is_err()
+                    {
+                        eprintln!("Failed to save updated catalog.");
+                        return;
+                    }
+                    debug!("New catalog saved.");
+                }
+            }
+
+            if let Some(message) = message
                 && !quiet
             {
-                println!("All aliases and groups are already {action}.");
-            }
-        }
-        Ok(Outcome::CatalogChanged) => {
-            if save_catalog(&catalog, &resolve_catalog_path(catalog_path.as_ref())).is_err() {
-                eprintln!("Failed to save updated catalog.");
-                return;
-            }
-            debug!("New catalog saved.");
-            if let Some(action) = bulk_action
-                && !quiet
-            {
-                println!("All aliases and groups are now {action}.");
+                println!("{message}");
             }
         }
         Err(_) => debug!("An error occurred during command execution."),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ mod core;
 
 use clap::Parser;
 
+use cli::disable::DisableTarget;
+use cli::enable::EnableTarget;
 use cli::{Cli, Commands};
 
 use catalog::io::{catalog_path as resolve_catalog_path, load_catalog, save_catalog};
@@ -34,6 +36,14 @@ use log::{LevelFilter, debug};
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn main() {
     let cli = Cli::parse();
+    let quiet = cli.quiet;
+    let bulk_action = match &cli.command {
+        Commands::Enable(cmd) if matches!(cmd.target, Some(EnableTarget::All)) => Some("enabled"),
+        Commands::Disable(cmd) if matches!(cmd.target, Some(DisableTarget::All)) => {
+            Some("disabled")
+        }
+        _ => None,
+    };
 
     // Determine log level based on CLI flags
     let level = if cli.quiet {
@@ -97,6 +107,11 @@ fn main() {
     match result {
         Ok(Outcome::NoChanges) => {
             debug!("No changes made to catalog or shell.");
+            if let Some(action) = bulk_action
+                && !quiet
+            {
+                println!("All aliases and groups are already {action}.");
+            }
         }
         Ok(Outcome::CatalogChanged) => {
             if save_catalog(&catalog, &resolve_catalog_path(catalog_path.as_ref())).is_err() {
@@ -104,6 +119,11 @@ fn main() {
                 return;
             }
             debug!("New catalog saved.");
+            if let Some(action) = bulk_action
+                && !quiet
+            {
+                println!("All aliases and groups are now {action}.");
+            }
         }
         Err(_) => debug!("An error occurred during command execution."),
     }

--- a/tests/shell_integration.rs
+++ b/tests/shell_integration.rs
@@ -106,6 +106,57 @@ __aliasmgr_prompt_sync
 }
 
 #[test]
+fn bulk_disable_and_enable_reconcile_all_managed_aliases() {
+    let catalog = tempfile::NamedTempFile::new().unwrap();
+    let script = r#"
+eval "$("$1" init bash --catalog "$2")"
+aliasmgr add alias top 'echo top'
+aliasmgr add group tools --disabled
+aliasmgr add alias grouped 'echo grouped' --group tools --disabled
+__aliasmgr_prompt_sync
+alias top | command grep -q 'echo top' || exit 40
+! alias grouped 2>/dev/null || exit 41
+
+disable_output="$(aliasmgr disable all)"
+[ "$disable_output" = 'All aliases and groups are now disabled.' ] || exit 42
+__aliasmgr_prompt_sync
+! alias top 2>/dev/null || exit 43
+
+disable_output="$(aliasmgr disable all)"
+[ "$disable_output" = 'All aliases and groups are already disabled.' ] || exit 44
+
+enable_output="$(aliasmgr enable all)"
+[ "$enable_output" = 'All aliases and groups are now enabled.' ] || exit 45
+__aliasmgr_prompt_sync
+alias top | command grep -q 'echo top' || exit 46
+alias grouped | command grep -q 'echo grouped' || exit 47
+
+enable_output="$(aliasmgr enable all)"
+[ "$enable_output" = 'All aliases and groups are already enabled.' ] || exit 48
+"#;
+
+    assert_success(run_shell("bash", script, catalog.path()).unwrap());
+}
+
+#[test]
+fn bulk_enable_and_disable_handle_an_empty_catalog() {
+    let catalog = tempfile::NamedTempFile::new().unwrap();
+    let script = r#"
+eval "$("$1" init bash --catalog "$2")"
+
+enable_output="$(aliasmgr enable all)"
+[ "$enable_output" = 'All aliases and groups are already enabled.' ] || exit 49
+
+disable_output="$(aliasmgr disable all)"
+[ "$disable_output" = 'All aliases and groups are already disabled.' ] || exit 50
+
+[ -z "$(aliasmgr --quiet enable all)" ] || exit 51
+"#;
+
+    assert_success(run_shell("bash", script, catalog.path()).unwrap());
+}
+
+#[test]
 fn removing_enabled_group_with_reassign_preserves_enabled_alias() {
     let catalog = tempfile::NamedTempFile::new().unwrap();
     let script = r#"


### PR DESCRIPTION
## Summary

- add `enable all` and `disable all` targets for aliases and groups
- keep bulk changes idempotent, persist them through the existing single-save path, and report changed/already-applied outcomes
- document the new targets and cover mixed state, empty catalogs, reserved `all` alias access, and shell reconciliation

## Acceptance criteria

- `enable all` enables every alias and group; `disable all` disables every alias and group
- empty and already-matching catalogs return clean, explicit no-op outcomes
- each changed bulk operation returns one catalog change for the existing persistence path
- prompt synchronization removes disabled managed aliases and restores enabled aliases
- CLI help and README documentation include both `all` targets

## Validation

- `cargo build --verbose`
- `cargo test --verbose` (217 unit tests and 8 shell integration tests passed)
- `cargo clippy`
- `cargo fmt --check`
- `git diff --check`
- `cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info` (217 unit tests and 8 shell integration tests passed; 96.75% line coverage)

Closes #20
