### PR TITLE
Add doctor command for config diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,16 @@ ll = { command = "ls -la", enabled = true }
 - `aliasmgr disable <name>` (disables the matching alias or group; prompts if both exist)
 - `aliasmgr disable alias <name>` (explicit form)
 - `aliasmgr disable group <name>`
+- `aliasmgr doctor` (also available as `aliasmgr validate`)
 
 For more details, use the `-h` or `--help` flags.
 
 Notes:
 - Alias names cannot be empty or contain whitespace or `=`.
 - Global aliases (`--global`) only work on zsh; they are skipped on other shells.
+- `aliasmgr doctor` checks the catalog without modifying it. Invalid alias names,
+  missing group references, and malformed structures are errors; shell-incompatible
+  global aliases are warnings. Errors produce a non-zero exit status for scripts.
 - `list --format json` emits an array of aliases with `name`, `command`, `group`, `enabled`, and `global` fields. Ungrouped aliases have a `null` group.
 
 ## Sync Behavior

--- a/src/app/add.rs
+++ b/src/app/add.rs
@@ -3,6 +3,7 @@ use crate::core::{Failure, Outcome};
 use crate::core::add::{add_alias, add_group};
 use crate::core::edit::edit_alias;
 use crate::core::r#move::move_alias;
+use crate::core::validation::is_valid_alias_name;
 
 use crate::catalog::types::{Alias, AliasCatalog};
 
@@ -130,11 +131,6 @@ fn handle_add_alias(
             }
         }
     }
-}
-
-pub fn is_valid_alias_name(name: &str) -> bool {
-    // Alias name must not contain white space or '='
-    !name.is_empty() && !name.chars().any(|c| c.is_whitespace()) && !name.contains('=')
 }
 
 /// Handle the 'add' command

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -1,0 +1,85 @@
+use crate::app::shell::ShellType;
+use crate::catalog::types::AliasCatalog;
+use crate::cli::doctor::DoctorCommand;
+use crate::core::validation::{ValidationReport, validate_catalog};
+use crate::core::{Failure, Outcome};
+
+fn plural<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str {
+    if count == 1 { singular } else { plural }
+}
+
+fn format_report(report: &ValidationReport, shell: &ShellType) -> (String, String) {
+    let mut standard = String::new();
+    let mut diagnostics = String::new();
+
+    for error in &report.errors {
+        diagnostics.push_str(&format!("ERROR: {error}\n"));
+    }
+    for warning in &report.warnings {
+        diagnostics.push_str(&format!("WARNING: {warning}\n"));
+    }
+
+    if report.errors.is_empty() && report.warnings.is_empty() {
+        standard.push_str(&format!("OK: Catalog is valid for {shell}.\n"));
+    } else {
+        standard.push_str(&format!(
+            "Validation found {} {} and {} {}.\n",
+            report.errors.len(),
+            plural(report.errors.len(), "error", "errors"),
+            report.warnings.len(),
+            plural(report.warnings.len(), "warning", "warnings"),
+        ));
+    }
+
+    (standard, diagnostics)
+}
+
+pub fn handle_doctor(
+    catalog: &AliasCatalog,
+    _cmd: DoctorCommand,
+    shell: &ShellType,
+) -> Result<Outcome, Failure> {
+    let report = validate_catalog(catalog, shell);
+    let (standard, diagnostics) = format_report(&report, shell);
+    print!("{standard}");
+    eprint!("{diagnostics}");
+
+    if report.is_valid() {
+        Ok(Outcome::NoChanges)
+    } else {
+        Err(Failure::InvalidCatalog)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_distinguishes_errors_and_warnings() {
+        let report = ValidationReport {
+            errors: vec!["bad alias".into()],
+            warnings: vec!["shell mismatch".into()],
+        };
+
+        let (standard, diagnostics) = format_report(&report, &ShellType::Bash);
+
+        assert_eq!(standard, "Validation found 1 error and 1 warning.\n");
+        assert!(diagnostics.contains("ERROR: bad alias"));
+        assert!(diagnostics.contains("WARNING: shell mismatch"));
+    }
+
+    #[test]
+    fn valid_report_names_active_shell() {
+        let report = ValidationReport {
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        };
+
+        let (standard, diagnostics) = format_report(&report, &ShellType::Zsh);
+
+        assert_eq!(standard, "OK: Catalog is valid for ZSH.\n");
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod add;
 pub(crate) mod disable;
+pub(crate) mod doctor;
 pub(crate) mod edit;
 pub(crate) mod enable;
 pub(crate) mod file_path;

--- a/src/catalog/io.rs
+++ b/src/catalog/io.rs
@@ -56,7 +56,7 @@ pub fn load_catalog(path: &PathBuf) -> Result<AliasCatalog> {
 
     let content = fs::read_to_string(path)?;
     let cfg: AliasCatalogSpec = toml::from_str(&content)?;
-    Ok(convert_spec_to_catalog(cfg))
+    convert_spec_to_catalog(cfg)
 }
 
 fn ensure_group_table<'a>(doc: &'a mut DocumentMut, name: &str) -> &'a mut Table {

--- a/src/catalog/spec.rs
+++ b/src/catalog/spec.rs
@@ -3,6 +3,7 @@
 //! alias catalogs, as well as functions to convert between the internal
 //! representation and the specification representation.
 
+use anyhow::{Result, bail};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
@@ -71,8 +72,8 @@ pub struct AliasCatalogSpec {
 ///
 /// # Returns
 /// * An Alias representation of the given AliasSpecTypes.
-fn convert_spec_to_alias(spec: AliasSpecTypes, group: Option<String>) -> Alias {
-    match spec {
+fn convert_spec_to_alias(spec: AliasSpecTypes, group: Option<String>) -> Result<Alias> {
+    Ok(match spec {
         AliasSpecTypes::Simple(command) => Alias::new(command, group, true, false),
         AliasSpecTypes::Detailed(alias_spec) => Alias {
             command: alias_spec.command,
@@ -81,8 +82,8 @@ fn convert_spec_to_alias(spec: AliasSpecTypes, group: Option<String>) -> Alias {
             detailed: true,
             global: alias_spec.global,
         },
-        AliasSpecTypes::Group(_) => panic!("nested groups are not supported"),
-    }
+        AliasSpecTypes::Group(_) => bail!("nested groups are not supported"),
+    })
 }
 
 /// Convert an AliasCatalogSpec to its corresponding AliasCatalog representation.
@@ -92,7 +93,7 @@ fn convert_spec_to_alias(spec: AliasSpecTypes, group: Option<String>) -> Alias {
 ///
 /// # Returns
 /// * An AliasCatalog representation of the given AliasCatalogSpec.
-pub fn convert_spec_to_catalog(spec: AliasCatalogSpec) -> AliasCatalog {
+pub fn convert_spec_to_catalog(spec: AliasCatalogSpec) -> Result<AliasCatalog> {
     let mut aliases = IndexMap::new();
     let mut groups = IndexMap::new();
 
@@ -102,23 +103,23 @@ pub fn convert_spec_to_catalog(spec: AliasCatalogSpec) -> AliasCatalog {
                 groups.insert(name.clone(), group_spec.enabled);
 
                 if let Some(alias_entry) = group_spec.ungrouped_alias {
-                    let alias = convert_spec_to_alias(*alias_entry, None);
+                    let alias = convert_spec_to_alias(*alias_entry, None)?;
                     aliases.insert(name.clone(), alias);
                 }
 
                 for (alias_name, alias_entry) in group_spec.aliases {
-                    let alias = convert_spec_to_alias(alias_entry, Some(name.clone()));
+                    let alias = convert_spec_to_alias(alias_entry, Some(name.clone()))?;
                     aliases.insert(alias_name, alias);
                 }
             }
             alias => {
-                let alias_cfg = convert_spec_to_alias(alias, None);
+                let alias_cfg = convert_spec_to_alias(alias, None)?;
                 aliases.insert(name, alias_cfg);
             }
         }
     }
 
-    AliasCatalog { aliases, groups }
+    Ok(AliasCatalog { aliases, groups })
 }
 
 #[cfg(test)]
@@ -130,12 +131,11 @@ mod tests {
     #[test]
     fn test_convert_spec_to_catalog() {
         let spec: AliasCatalogSpec = toml::from_str(SAMPLE_TOML).unwrap();
-        let catalog = convert_spec_to_catalog(spec);
+        let catalog = convert_spec_to_catalog(spec).unwrap();
         assert_eq!(catalog, expected_catalog());
     }
 
     #[test]
-    #[should_panic = "nested groups are not supported"]
     fn test_nested_group_handling() {
         let toml_data = r#"
         [group1]
@@ -148,6 +148,11 @@ mod tests {
         "#;
 
         let spec: AliasCatalogSpec = toml::from_str(toml_data).unwrap();
-        convert_spec_to_catalog(spec);
+        let error = convert_spec_to_catalog(spec).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("nested groups are not supported")
+        );
     }
 }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,0 +1,4 @@
+use clap::Args;
+
+#[derive(Args)]
+pub struct DoctorCommand {}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 pub(crate) mod add;
 pub(crate) mod disable;
+pub(crate) mod doctor;
 pub(crate) mod edit;
 pub(crate) mod enable;
 pub(crate) mod init;
@@ -16,6 +17,7 @@ pub(crate) mod interaction;
 
 use add::AddCommand;
 use disable::DisableCommand;
+use doctor::DoctorCommand;
 use edit::EditCommand;
 use enable::EnableCommand;
 use init::InitCommand;
@@ -86,6 +88,10 @@ pub enum Commands {
     /// Disable an alias or alias group
     #[command(visible_alias = "ds")]
     Disable(DisableCommand),
+
+    /// Check catalog correctness and shell compatibility
+    #[command(visible_alias = "validate")]
+    Doctor(DoctorCommand),
 
     /// Rename an existing alias or alias group
     #[command(visible_alias = "rn")]
@@ -391,5 +397,14 @@ mod tests {
         };
         assert!(cmd.if_changed);
         assert!(!cmd.force);
+    }
+
+    #[test]
+    fn parses_doctor_and_validate_alias() {
+        let doctor = Cli::try_parse_from(["aliasmgr", "doctor"]).unwrap();
+        assert!(matches!(doctor.command, Commands::Doctor(_)));
+
+        let validate = Cli::try_parse_from(["aliasmgr", "validate"]).unwrap();
+        assert!(matches!(validate.command, Commands::Doctor(_)));
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod remove;
 pub(crate) mod rename;
 pub(crate) mod sort;
 pub(crate) mod sync;
+pub(crate) mod validation;
 
 /// Represents possible failure cases in core operations.
 #[derive(Debug, PartialEq, Eq)]
@@ -18,6 +19,7 @@ pub enum Failure {
     GroupDoesNotExist,
     AliasAlreadyExists,
     GroupAlreadyExists,
+    InvalidCatalog,
 }
 
 /// Represents the outcome of core operations.

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -1,6 +1,6 @@
-use crate::app::add::is_valid_alias_name;
 use crate::app::shell::{ShellType, shell_quote};
 use crate::catalog::types::{Alias, AliasCatalog};
+use crate::core::validation::is_valid_alias_name;
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 pub const MANAGED_ALIASES_ENV_VAR: &str = "ALIASMGR_MANAGED_ALIASES";

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -1,0 +1,114 @@
+use crate::app::shell::ShellType;
+use crate::catalog::types::AliasCatalog;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ValidationReport {
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl ValidationReport {
+    pub fn is_valid(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+pub fn is_valid_alias_name(name: &str) -> bool {
+    !name.is_empty() && !name.chars().any(char::is_whitespace) && !name.contains('=')
+}
+
+pub fn validate_catalog(catalog: &AliasCatalog, shell: &ShellType) -> ValidationReport {
+    let mut report = ValidationReport {
+        errors: Vec::new(),
+        warnings: Vec::new(),
+    };
+
+    for (name, alias) in &catalog.aliases {
+        if !is_valid_alias_name(name) {
+            report.errors.push(format!(
+                "Alias '{name}' has an invalid name; names must not be empty or contain whitespace or '='."
+            ));
+        }
+
+        if let Some(group) = &alias.group
+            && !catalog.groups.contains_key(group)
+        {
+            report.errors.push(format!(
+                "Alias '{name}' references missing group '{group}'."
+            ));
+        }
+
+        if alias.global && *shell != ShellType::Zsh {
+            report.warnings.push(format!(
+                "Global alias '{name}' is unsupported in {shell} and will be skipped."
+            ));
+        }
+    }
+
+    report
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::catalog::types::{Alias, AliasCatalog};
+
+    fn alias(group: Option<&str>, global: bool) -> Alias {
+        Alias::new("echo test".into(), group.map(str::to_owned), true, global)
+    }
+
+    #[test]
+    fn invalid_alias_name_is_reported() {
+        let mut catalog = AliasCatalog::new();
+        catalog
+            .aliases
+            .insert("invalid name".into(), alias(None, false));
+
+        let report = validate_catalog(&catalog, &ShellType::Zsh);
+
+        assert!(!report.is_valid());
+        assert!(report.errors[0].contains("invalid name"));
+    }
+
+    #[test]
+    fn missing_group_reference_is_reported() {
+        let mut catalog = AliasCatalog::new();
+        catalog
+            .aliases
+            .insert("build".into(), alias(Some("missing"), false));
+
+        let report = validate_catalog(&catalog, &ShellType::Zsh);
+
+        assert!(!report.is_valid());
+        assert!(report.errors[0].contains("missing group 'missing'"));
+    }
+
+    #[test]
+    fn global_alias_incompatibility_is_a_bash_warning() {
+        let mut catalog = AliasCatalog::new();
+        catalog.aliases.insert("glob".into(), alias(None, true));
+
+        let report = validate_catalog(&catalog, &ShellType::Bash);
+
+        assert!(report.is_valid());
+        assert_eq!(report.warnings.len(), 1);
+        assert!(report.warnings[0].contains("unsupported in BASH"));
+    }
+
+    #[test]
+    fn valid_catalog_returns_success() {
+        let mut catalog = AliasCatalog::new();
+        catalog.groups.insert("dev".into(), true);
+        catalog
+            .aliases
+            .insert("build".into(), alias(Some("dev"), false));
+        catalog.aliases.insert("glob".into(), alias(None, true));
+
+        let report = validate_catalog(&catalog, &ShellType::Zsh);
+
+        assert!(report.is_valid());
+        assert!(report.errors.is_empty());
+        assert!(report.warnings.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use core::Outcome;
 
 use app::add::handle_add;
 use app::disable::handle_disable;
+use app::doctor::handle_doctor;
 use app::edit::handle_edit;
 use app::enable::handle_enable;
 use app::file_path::determine_catalog_path;
@@ -57,6 +58,8 @@ fn main() {
     let mut catalog_path = None;
     let mut shell = DEFAULT_SHELL;
 
+    let is_doctor = matches!(&cli.command, Commands::Doctor(_));
+
     if !matches!(cli.command, Commands::Init(_)) {
         shell = determine_shell();
         debug!("Determined shell: {}", shell);
@@ -65,8 +68,18 @@ fn main() {
             .expect("Custom catalog path did not exist and user chose not to use it.");
         debug!("Using catalog path: {:?}", catalog_path);
 
-        catalog = load_catalog(&resolve_catalog_path(catalog_path.as_ref()))
-            .expect("Failed to load catalog");
+        let resolved_catalog_path = resolve_catalog_path(catalog_path.as_ref());
+        catalog = match load_catalog(&resolved_catalog_path) {
+            Ok(catalog) => catalog,
+            Err(error) if is_doctor => {
+                eprintln!(
+                    "ERROR: Could not load catalog '{}': {error}",
+                    resolved_catalog_path.display()
+                );
+                std::process::exit(1);
+            }
+            Err(error) => panic!("Failed to load catalog: {error}"),
+        };
         debug!("Loaded catalog: {:?}", catalog);
     }
 
@@ -81,6 +94,7 @@ fn main() {
         Commands::Sort(cmd) => handle_sort(&mut catalog, cmd),
         Commands::Enable(cmd) => handle_enable(&mut catalog, cmd, &shell),
         Commands::Disable(cmd) => handle_disable(&mut catalog, cmd, &shell),
+        Commands::Doctor(cmd) => handle_doctor(&catalog, cmd, &shell),
         Commands::Sync(cmd) => handle_sync(cmd),
         Commands::ShellSync(cmd) => {
             print!("{}", handle_shell_sync(&catalog, &shell, cmd));
@@ -105,6 +119,11 @@ fn main() {
             }
             debug!("New catalog saved.");
         }
-        Err(_) => debug!("An error occurred during command execution."),
+        Err(_) => {
+            debug!("An error occurred during command execution.");
+            if is_doctor {
+                std::process::exit(1);
+            }
+        }
     }
 }

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -1,0 +1,76 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_doctor(catalog: &Path, shell: &str) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .arg("doctor")
+        .env("ALIASMGR_CATALOG_PATH", catalog)
+        .env("ALIASMGR_SHELL", shell)
+        .output()
+        .expect("doctor command should run")
+}
+
+#[test]
+fn valid_catalog_succeeds_without_modification() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original = "ll = \"ls -la\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    let output = run_doctor(&catalog, "bash");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("OK: Catalog is valid for BASH."));
+    assert!(output.stderr.is_empty());
+    assert_eq!(fs::read_to_string(catalog).unwrap(), original);
+}
+
+#[test]
+fn invalid_alias_name_fails() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "\"invalid name\" = \"echo invalid\"\n").unwrap();
+
+    let output = run_doctor(&catalog, "zsh");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ERROR: Alias 'invalid name'"));
+}
+
+#[test]
+fn global_alias_on_bash_warns_but_succeeds() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "glob = { command = \"*.rs\", global = true }\n").unwrap();
+
+    let output = run_doctor(&catalog, "bash");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("WARNING: Global alias 'glob'"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("0 errors and 1 warning"));
+}
+
+#[test]
+fn malformed_catalog_fails_cleanly() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "alias = {").unwrap();
+
+    let output = run_doctor(&catalog, "bash");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ERROR: Could not load catalog"));
+}
+
+#[test]
+fn unsupported_nested_group_fails_cleanly() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "[tools]\n[tools.nested]\nll = \"ls -la\"\n").unwrap();
+
+    let output = run_doctor(&catalog, "bash");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("nested groups are not supported"));
+}


### PR DESCRIPTION
## Summary

- add `aliasmgr doctor` with `validate` as a visible alias
- centralize catalog checks for invalid alias names, missing group references, and active-shell global alias compatibility
- report malformed and unsupported catalog structures cleanly instead of panicking
- keep diagnostics non-mutating and return a non-zero status only for validation errors

## Acceptance criteria

- **Non-mutating:** integration coverage verifies the catalog remains byte-for-byte unchanged
- **Errors vs. warnings:** diagnostics use explicit `ERROR:` and `WARNING:` prefixes and a count summary
- **Script-friendly:** validation and parse errors exit non-zero; compatibility warnings remain successful
- **Known invalid states:** invalid names, missing groups, Bash global aliases, malformed TOML, and nested groups are covered

## Validation

- `cargo build --verbose`
- `cargo test --verbose` (222 unit tests, 5 doctor integration tests, 6 shell integration tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info`

Closes #3
