### PR TITLE
Warn when aliases conflict with commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ For more details, use the `-h` or `--help` flags.
 Notes:
 - Alias names cannot be empty or contain whitespace or `=`.
 - Global aliases (`--global`) only work on zsh; they are skipped on other shells.
+- Adding or editing an alias warns without blocking when its name conflicts with a
+  builtin in the active Bash/Zsh shell or an executable found on `PATH`.
 - `aliasmgr doctor` checks the catalog without modifying it. Invalid alias names,
   missing group references, and malformed structures are errors; shell-incompatible
-  global aliases are warnings. Errors produce a non-zero exit status for scripts.
+  global aliases and command conflicts are warnings. Errors produce a non-zero exit
+  status for scripts.
 - `list --format json` emits an array of aliases with `name`, `command`, `group`, `enabled`, and `global` fields. Ungrouped aliases have a `null` group.
 
 ## Sync Behavior

--- a/src/app/add.rs
+++ b/src/app/add.rs
@@ -1,6 +1,7 @@
 use crate::core::{Failure, Outcome};
 
 use crate::core::add::{add_alias, add_group};
+use crate::core::conflict::conflict_warnings;
 use crate::core::edit::edit_alias;
 use crate::core::r#move::move_alias;
 use crate::core::validation::is_valid_alias_name;
@@ -14,7 +15,7 @@ use super::list::format_alias_info;
 
 use super::shell::ShellType;
 
-use log::{error, info};
+use log::{error, info, warn};
 
 /// Handle overwriting an existing alias
 fn handle_overwrite_existing_alias(
@@ -160,13 +161,25 @@ pub fn handle_add(
             }
 
             let new_alias = Alias::new(args.command, args.group, !args.disabled, args.global);
-            handle_add_alias(
+            let outcome = handle_add_alias(
                 catalog,
                 &args.name,
                 &new_alias,
                 prompt_overwrite_existing_alias,
                 prompt_create_non_existent_group,
-            )
+            )?;
+
+            if outcome == Outcome::CatalogChanged {
+                for warning in conflict_warnings([args.name.as_str()], shell)
+                    .get(&args.name)
+                    .into_iter()
+                    .flatten()
+                {
+                    warn!("{warning}");
+                }
+            }
+
+            Ok(outcome)
         }
 
         // Add group

--- a/src/app/add.rs
+++ b/src/app/add.rs
@@ -134,6 +134,24 @@ fn handle_add_alias(
     }
 }
 
+fn warn_conflicts_after_change(
+    result: Result<Outcome, Failure>,
+    name: &str,
+    shell: &ShellType,
+) -> Result<Outcome, Failure> {
+    if result == Ok(Outcome::CatalogChanged) {
+        for warning in conflict_warnings([name], shell)
+            .get(name)
+            .into_iter()
+            .flatten()
+        {
+            warn!("{warning}");
+        }
+    }
+
+    result
+}
+
 /// Handle the 'add' command
 pub fn handle_add(
     catalog: &mut AliasCatalog,
@@ -161,25 +179,17 @@ pub fn handle_add(
             }
 
             let new_alias = Alias::new(args.command, args.group, !args.disabled, args.global);
-            let outcome = handle_add_alias(
-                catalog,
+            warn_conflicts_after_change(
+                handle_add_alias(
+                    catalog,
+                    &args.name,
+                    &new_alias,
+                    prompt_overwrite_existing_alias,
+                    prompt_create_non_existent_group,
+                ),
                 &args.name,
-                &new_alias,
-                prompt_overwrite_existing_alias,
-                prompt_create_non_existent_group,
-            )?;
-
-            if outcome == Outcome::CatalogChanged {
-                for warning in conflict_warnings([args.name.as_str()], shell)
-                    .get(&args.name)
-                    .into_iter()
-                    .flatten()
-                {
-                    warn!("{warning}");
-                }
-            }
-
-            Ok(outcome)
+                shell,
+            )
         }
 
         // Add group
@@ -221,6 +231,18 @@ mod tests {
         assert_eq!(
             catalog.aliases.get(SAMPLE_ALIAS_NAME),
             Some(&sample_alias())
+        );
+    }
+
+    #[test]
+    fn test_conflict_warnings_only_follow_catalog_changes() {
+        assert_eq!(
+            warn_conflicts_after_change(Ok(Outcome::NoChanges), "cd", &ShellType::Bash),
+            Ok(Outcome::NoChanges)
+        );
+        assert_eq!(
+            warn_conflicts_after_change(Err(Failure::GroupDoesNotExist), "cd", &ShellType::Bash),
+            Err(Failure::GroupDoesNotExist)
         );
     }
 

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -8,18 +8,22 @@ fn plural<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str {
     if count == 1 { singular } else { plural }
 }
 
-fn format_report(report: &ValidationReport, shell: &ShellType) -> (String, String) {
+fn format_report(report: &ValidationReport, shell: &ShellType, quiet: bool) -> (String, String) {
     let mut standard = String::new();
     let mut diagnostics = String::new();
 
     for error in &report.errors {
         diagnostics.push_str(&format!("ERROR: {error}\n"));
     }
-    for warning in &report.warnings {
-        diagnostics.push_str(&format!("WARNING: {warning}\n"));
+    if !quiet {
+        for warning in &report.warnings {
+            diagnostics.push_str(&format!("WARNING: {warning}\n"));
+        }
     }
 
-    if report.errors.is_empty() && report.warnings.is_empty() {
+    if quiet {
+        return (standard, diagnostics);
+    } else if report.errors.is_empty() && report.warnings.is_empty() {
         standard.push_str(&format!("OK: Catalog is valid for {shell}.\n"));
     } else {
         standard.push_str(&format!(
@@ -38,9 +42,10 @@ pub fn handle_doctor(
     catalog: &AliasCatalog,
     _cmd: DoctorCommand,
     shell: &ShellType,
+    quiet: bool,
 ) -> Result<Outcome, Failure> {
     let report = validate_catalog(catalog, shell);
-    let (standard, diagnostics) = format_report(&report, shell);
+    let (standard, diagnostics) = format_report(&report, shell, quiet);
     print!("{standard}");
     eprint!("{diagnostics}");
 
@@ -63,7 +68,7 @@ mod tests {
             warnings: vec!["shell mismatch".into()],
         };
 
-        let (standard, diagnostics) = format_report(&report, &ShellType::Bash);
+        let (standard, diagnostics) = format_report(&report, &ShellType::Bash, false);
 
         assert_eq!(standard, "Validation found 1 error and 1 warning.\n");
         assert!(diagnostics.contains("ERROR: bad alias"));
@@ -77,9 +82,22 @@ mod tests {
             warnings: Vec::new(),
         };
 
-        let (standard, diagnostics) = format_report(&report, &ShellType::Zsh);
+        let (standard, diagnostics) = format_report(&report, &ShellType::Zsh, false);
 
         assert_eq!(standard, "OK: Catalog is valid for ZSH.\n");
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn quiet_report_only_prints_errors() {
+        let report = ValidationReport {
+            errors: vec!["bad alias".into()],
+            warnings: vec!["shell mismatch".into()],
+        };
+
+        let (standard, diagnostics) = format_report(&report, &ShellType::Bash, true);
+
+        assert!(standard.is_empty());
+        assert_eq!(diagnostics, "ERROR: bad alias\n");
     }
 }

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -1,8 +1,12 @@
 use crate::catalog::types::{Alias, AliasCatalog};
 use crate::cli::edit::EditCommand;
 use crate::cli::interaction::prompt_create_non_existent_group;
+use crate::core::conflict::conflict_warnings;
 use crate::core::edit::edit_alias;
 use crate::core::{Failure, Outcome};
+use log::warn;
+
+use super::shell::ShellType;
 
 fn handle_nonexistent_group(
     catalog: &mut AliasCatalog,
@@ -17,7 +21,11 @@ fn handle_nonexistent_group(
     }
 }
 
-pub fn handle_edit(catalog: &mut AliasCatalog, cmd: EditCommand) -> Result<Outcome, Failure> {
+pub fn handle_edit(
+    catalog: &mut AliasCatalog,
+    cmd: EditCommand,
+    shell: &ShellType,
+) -> Result<Outcome, Failure> {
     let mut new_alias = Alias::new("".into(), None, true, false); // Default initialization
 
     if let Some(old_alias) = catalog.aliases.get(&cmd.name) {
@@ -45,7 +53,17 @@ pub fn handle_edit(catalog: &mut AliasCatalog, cmd: EditCommand) -> Result<Outco
 
     // If no old alias found, edit_alias will return the appropriate error, and we can just use the
     // default new_alias as a placeholder.
-    edit_alias(catalog, &cmd.name, &new_alias)
+    let outcome = edit_alias(catalog, &cmd.name, &new_alias)?;
+
+    for warning in conflict_warnings([cmd.name.as_str()], shell)
+        .get(&cmd.name)
+        .into_iter()
+        .flatten()
+    {
+        warn!("{warning}");
+    }
+
+    Ok(outcome)
 }
 
 #[cfg(test)]
@@ -73,7 +91,7 @@ mod tests {
             toggle_global: false,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd);
+        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edited_command");
@@ -89,7 +107,7 @@ mod tests {
             toggle_global: false,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd);
+        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
         assert!(result.is_err());
         assert_eq!(result.err(), Some(Failure::AliasDoesNotExist));
     }
@@ -104,7 +122,7 @@ mod tests {
             toggle_global: false,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd);
+        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edit_command");
@@ -121,7 +139,7 @@ mod tests {
             toggle_global: true,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd);
+        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edit_command");
@@ -139,7 +157,7 @@ mod tests {
             toggle_global: false,
             group: Some(Some("dev".into())),
         };
-        let result = handle_edit(&mut catalog, cmd);
+        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edit_command");

--- a/src/core/conflict.rs
+++ b/src/core/conflict.rs
@@ -1,0 +1,199 @@
+use crate::app::shell::ShellType;
+use indexmap::IndexMap;
+use log::debug;
+use std::collections::HashSet;
+use std::env;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+const BASH_BUILTIN_QUERY: &str = r#"
+for name do
+    if [ "$(builtin type -t -- "$name")" = "builtin" ]; then
+        printf '%s\0' "$name"
+    fi
+done
+"#;
+
+const ZSH_BUILTIN_QUERY: &str = r#"
+for name do
+    if [ "$(builtin whence -w -- "$name")" = "$name: builtin" ]; then
+        printf '%s\0' "$name"
+    fi
+done
+"#;
+
+fn shell_builtin_names(names: &[String], shell: &ShellType) -> HashSet<String> {
+    let (program, options, query) = match shell {
+        ShellType::Bash => (
+            "bash",
+            ["--noprofile", "--norc", "-c"].as_slice(),
+            BASH_BUILTIN_QUERY,
+        ),
+        ShellType::Zsh => ("zsh", ["-dfc"].as_slice(), ZSH_BUILTIN_QUERY),
+    };
+
+    let output = Command::new(program)
+        .args(options)
+        .arg(query)
+        .arg("aliasmgr")
+        .args(names)
+        .env_remove("BASH_ENV")
+        .output();
+
+    let Ok(output) = output else {
+        debug!("Could not query {shell} builtins; continuing with PATH checks.");
+        return HashSet::new();
+    };
+
+    if !output.status.success() {
+        debug!("{shell} builtin query failed; continuing with PATH checks.");
+        return HashSet::new();
+    }
+
+    output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+        .filter_map(|name| String::from_utf8(name.to_vec()).ok())
+        .collect()
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    path.metadata()
+        .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn executable_on_path(name: &str, path: Option<&OsStr>) -> Option<PathBuf> {
+    if name.contains('/') {
+        return None;
+    }
+
+    path.and_then(|path| {
+        env::split_paths(path)
+            .map(|directory| directory.join(name))
+            .find(|candidate| is_executable(candidate))
+    })
+}
+
+fn conflict_warnings_with(
+    names: &[String],
+    shell: &ShellType,
+    builtin_names: &HashSet<String>,
+    path: Option<&OsStr>,
+) -> IndexMap<String, Vec<String>> {
+    let mut warnings = IndexMap::new();
+
+    for name in names {
+        let mut alias_warnings = Vec::new();
+
+        if builtin_names.contains(name) {
+            alias_warnings.push(format!(
+                "Alias '{name}' conflicts with a {shell} shell builtin."
+            ));
+        }
+
+        if let Some(executable) = executable_on_path(name, path) {
+            alias_warnings.push(format!(
+                "Alias '{name}' shadows executable '{}' found on PATH.",
+                executable.display()
+            ));
+        }
+
+        if !alias_warnings.is_empty() {
+            warnings.insert(name.clone(), alias_warnings);
+        }
+    }
+
+    warnings
+}
+
+pub fn conflict_warnings<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+    shell: &ShellType,
+) -> IndexMap<String, Vec<String>> {
+    let names = names.into_iter().map(str::to_owned).collect::<Vec<_>>();
+    let builtin_names = shell_builtin_names(&names, shell);
+    let path = env::var_os("PATH");
+    conflict_warnings_with(&names, shell, &builtin_names, path.as_deref())
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[cfg(unix)]
+    fn make_executable(path: &Path) {
+        fs::write(path, "executable").unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reports_builtin_and_path_conflicts_separately() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("echo");
+        make_executable(&executable);
+        let path = env::join_paths([directory.path()]).unwrap();
+        let names = vec!["echo".to_string()];
+        let builtin_names = HashSet::from(["echo".to_string()]);
+
+        let warnings = conflict_warnings_with(
+            &names,
+            &ShellType::Bash,
+            &builtin_names,
+            Some(path.as_os_str()),
+        );
+
+        assert_eq!(warnings["echo"].len(), 2);
+        assert!(warnings["echo"][0].contains("BASH shell builtin"));
+        assert!(warnings["echo"][1].contains(executable.to_string_lossy().as_ref()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ignores_non_executable_files_on_path() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("notes"), "not executable").unwrap();
+        let path = env::join_paths([directory.path()]).unwrap();
+        let names = vec!["notes".to_string()];
+
+        let warnings = conflict_warnings_with(
+            &names,
+            &ShellType::Zsh,
+            &HashSet::new(),
+            Some(path.as_os_str()),
+        );
+
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn non_conflicting_alias_has_no_warning() {
+        let names = vec!["aliasmgr_definitely_unique".to_string()];
+        let warnings = conflict_warnings_with(&names, &ShellType::Bash, &HashSet::new(), None);
+
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn shell_queries_are_batched_and_pass_names_as_arguments() {
+        assert!(BASH_BUILTIN_QUERY.contains("builtin type -t -- \"$name\""));
+        assert!(ZSH_BUILTIN_QUERY.contains("builtin whence -w -- \"$name\""));
+        assert!(BASH_BUILTIN_QUERY.contains("for name do"));
+        assert!(ZSH_BUILTIN_QUERY.contains("for name do"));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod add;
+pub(crate) mod conflict;
 pub(crate) mod disable;
 pub(crate) mod edit;
 pub(crate) mod enable;

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -1,5 +1,6 @@
 use crate::app::shell::ShellType;
 use crate::catalog::types::AliasCatalog;
+use crate::core::conflict::conflict_warnings;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ValidationReport {
@@ -23,6 +24,13 @@ pub fn validate_catalog(catalog: &AliasCatalog, shell: &ShellType) -> Validation
         warnings: Vec::new(),
     };
 
+    let valid_names = catalog
+        .aliases
+        .keys()
+        .filter(|name| is_valid_alias_name(name))
+        .map(String::as_str);
+    let conflicts = conflict_warnings(valid_names, shell);
+
     for (name, alias) in &catalog.aliases {
         if !is_valid_alias_name(name) {
             report.errors.push(format!(
@@ -42,6 +50,10 @@ pub fn validate_catalog(catalog: &AliasCatalog, shell: &ShellType) -> Validation
             report.warnings.push(format!(
                 "Global alias '{name}' is unsupported in {shell} and will be skipped."
             ));
+        }
+
+        if let Some(conflict_warnings) = conflicts.get(name) {
+            report.warnings.extend(conflict_warnings.iter().cloned());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,11 +92,13 @@ fn main() {
         Commands::Move(cmd) => handle_move(&mut catalog, cmd).map(CommandOutcome::from),
         Commands::List(cmd) => handle_list(&catalog, cmd, &shell).map(CommandOutcome::from),
         Commands::Rename(cmd) => handle_rename(&mut catalog, cmd).map(CommandOutcome::from),
-        Commands::Edit(cmd) => handle_edit(&mut catalog, cmd).map(CommandOutcome::from),
+        Commands::Edit(cmd) => handle_edit(&mut catalog, cmd, &shell).map(CommandOutcome::from),
         Commands::Sort(cmd) => handle_sort(&mut catalog, cmd).map(CommandOutcome::from),
         Commands::Enable(cmd) => handle_enable(&mut catalog, cmd, &shell),
         Commands::Disable(cmd) => handle_disable(&mut catalog, cmd, &shell),
-        Commands::Doctor(cmd) => handle_doctor(&catalog, cmd, &shell).map(CommandOutcome::from),
+        Commands::Doctor(cmd) => {
+            handle_doctor(&catalog, cmd, &shell, quiet).map(CommandOutcome::from)
+        }
         Commands::Sync(cmd) => handle_sync(cmd).map(CommandOutcome::from),
         Commands::ShellSync(cmd) => {
             print!("{}", handle_shell_sync(&catalog, &shell, cmd));

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -137,6 +137,25 @@ fn non_conflicting_add_is_quiet() {
 }
 
 #[test]
+fn unavailable_builtin_result_and_slash_name_remain_non_blocking() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let fake_bash = directory.path().join("bash");
+    fs::write(&catalog, "").unwrap();
+    make_executable(&fake_bash, "#!/bin/sh\nexit 1\n");
+
+    let output = run_aliasmgr(
+        &catalog,
+        "bash",
+        directory.path(),
+        &["add", "path/tool", "echo unique"],
+    );
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
 fn quiet_suppresses_conflict_warnings() {
     let directory = tempfile::tempdir().unwrap();
     let catalog = directory.path().join("aliases.toml");

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -1,0 +1,157 @@
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn make_executable(path: &Path, content: &str) {
+    fs::write(path, content).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn run_aliasmgr(catalog: &Path, shell: &str, path: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(args)
+        .env("ALIASMGR_CATALOG_PATH", catalog)
+        .env("ALIASMGR_SHELL", shell)
+        .env("PATH", path)
+        .output()
+        .expect("aliasmgr command should run")
+}
+
+#[test]
+fn add_warns_for_executable_on_path() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let executable = directory.path().join("shadowed-tool");
+    fs::write(&catalog, "").unwrap();
+    make_executable(&executable, "executable");
+
+    let output = run_aliasmgr(
+        &catalog,
+        "bash",
+        directory.path(),
+        &["add", "shadowed-tool", "echo shadowed"],
+    );
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains(&format!(
+        "Alias 'shadowed-tool' shadows executable '{}' found on PATH.",
+        executable.display()
+    )));
+}
+
+#[test]
+fn add_warns_for_bash_builtin() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "").unwrap();
+    let path = env::var_os("PATH").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(["add", "cd", "echo cd"])
+        .env("ALIASMGR_CATALOG_PATH", &catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Alias 'cd' conflicts with a BASH shell builtin.")
+    );
+}
+
+#[test]
+fn add_uses_zsh_builtin_query_without_a_static_list() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let fake_zsh = directory.path().join("zsh");
+    fs::write(&catalog, "").unwrap();
+    make_executable(&fake_zsh, "#!/bin/sh\nprintf 'cd\\0'\n");
+
+    let output = run_aliasmgr(&catalog, "zsh", directory.path(), &["add", "cd", "echo cd"]);
+
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Alias 'cd' conflicts with a ZSH shell builtin.")
+    );
+}
+
+#[test]
+fn edit_and_doctor_warn_for_existing_conflict() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "cd = \"echo old\"\n").unwrap();
+    let path = env::var_os("PATH").unwrap();
+
+    let edit = Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(["edit", "cd", "echo new"])
+        .env("ALIASMGR_CATALOG_PATH", &catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    let doctor = Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .arg("doctor")
+        .env("ALIASMGR_CATALOG_PATH", &catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(edit.status.success());
+    assert!(
+        String::from_utf8_lossy(&edit.stderr)
+            .contains("Alias 'cd' conflicts with a BASH shell builtin.")
+    );
+    assert!(doctor.status.success());
+    assert!(
+        String::from_utf8_lossy(&doctor.stderr)
+            .contains("WARNING: Alias 'cd' conflicts with a BASH shell builtin.")
+    );
+    assert!(String::from_utf8_lossy(&doctor.stdout).contains("0 errors and"));
+}
+
+#[test]
+fn non_conflicting_add_is_quiet() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "").unwrap();
+
+    let output = run_aliasmgr(
+        &catalog,
+        "bash",
+        directory.path(),
+        &["add", "aliasmgr_definitely_unique", "echo unique"],
+    );
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn quiet_suppresses_conflict_warnings() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "cd = \"echo cd\"\n").unwrap();
+    let path = env::var_os("PATH").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(["--quiet", "doctor"])
+        .env("ALIASMGR_CATALOG_PATH", &catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}


### PR DESCRIPTION
## Summary

- detect alias names that match Bash/Zsh builtins by querying the selected shell at runtime
- detect executable collisions on the current `PATH` without executing the target command
- warn after successful add, overwrite, and edit operations, and include conflicts in `doctor`
- keep warnings non-blocking and suppress them with `--quiet`

## Acceptance criteria

- Conflicting adds and edits surface builtin and/or executable warnings on stderr.
- Non-conflicting aliases produce no warning output.
- Bash and Zsh use their own runtime builtin resolution rather than a static list.
- `doctor` reports conflicts in existing catalogs while retaining a successful exit status for warnings alone.
- Disabled and global aliases receive the same checks because they can later become active.

## Validation

- `cargo build --verbose`
- `cargo test` (234 unit, 7 conflict CLI, 5 doctor, and 8 shell integration tests passed)
- `cargo +nightly llvm-cov --all-features --workspace --lcov` (all changed lines covered locally)
- `cargo clippy`
- `cargo fmt --check`
- `git diff --check`
- manual Bash query: `builtin type -t -- cd` returned `builtin`
- manual Zsh query: `builtin whence -w -- cd` returned `cd: builtin`

Closes #8
