### PR TITLE
Add non-interactive prompt controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ ll = { command = "ls -la", enabled = true }
 For more details, use the `-h` or `--help` flags.
 
 Notes:
+- `--force` and `--no-input` are mutually exclusive global automation flags.
+  `--force` accepts every prompt and selects aliases when an alias and group have
+  the same name. `--no-input` exits with status 2 if a command would prompt.
+  Without either flag, prompt behavior remains interactive.
 - Alias names cannot be empty or contain whitespace or `=`.
 - Global aliases (`--global`) only work on zsh; they are skipped on other shells.
 - Adding or editing an alias warns without blocking when its name conflicts with a

--- a/src/app/add.rs
+++ b/src/app/add.rs
@@ -9,7 +9,9 @@ use crate::core::validation::is_valid_alias_name;
 use crate::catalog::types::{Alias, AliasCatalog};
 
 use crate::cli::add::{AddCommand, AddTarget};
-use crate::cli::interaction::{prompt_create_non_existent_group, prompt_overwrite_existing_alias};
+use crate::cli::interaction::{
+    InteractionMode, prompt_create_non_existent_group, prompt_overwrite_existing_alias,
+};
 
 use super::list::format_alias_info;
 
@@ -157,6 +159,7 @@ pub fn handle_add(
     catalog: &mut AliasCatalog,
     cmd: AddCommand,
     shell: &ShellType,
+    interaction_mode: InteractionMode,
 ) -> Result<Outcome, Failure> {
     let target = cmd
         .target
@@ -184,8 +187,8 @@ pub fn handle_add(
                     catalog,
                     &args.name,
                     &new_alias,
-                    prompt_overwrite_existing_alias,
-                    prompt_create_non_existent_group,
+                    |alias| prompt_overwrite_existing_alias(interaction_mode, alias),
+                    |group| prompt_create_non_existent_group(interaction_mode, group),
                 ),
                 &args.name,
                 shell,
@@ -262,6 +265,7 @@ mod tests {
                 },
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -405,6 +409,7 @@ mod tests {
                 alias: Default::default(),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_ok());
         assert!(catalog.groups.contains_key("dev"));
@@ -424,6 +429,7 @@ mod tests {
                 alias: Default::default(),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_err());
         assert_matches!(result.err().unwrap(), Failure::GroupAlreadyExists);
@@ -446,6 +452,7 @@ mod tests {
                 alias: Default::default(),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_err());
         assert_matches!(result.err().unwrap(), Failure::UnsupportedGlobalAlias);
@@ -468,6 +475,7 @@ mod tests {
                 alias: Default::default(),
             },
             &ShellType::Zsh,
+            InteractionMode::Interactive,
         );
         assert!(result.is_ok());
         assert_eq!(
@@ -506,6 +514,7 @@ mod tests {
                 alias: Default::default(),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_err());
         assert_matches!(result.err().unwrap(), Failure::InvalidAliasName);
@@ -528,6 +537,7 @@ mod tests {
                 alias: Default::default(),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_err());
         assert_matches!(result.err().unwrap(), Failure::InvalidAliasName);

--- a/src/app/disable.rs
+++ b/src/app/disable.rs
@@ -3,7 +3,7 @@ use crate::core::disable::{disable_alias, disable_all, disable_group};
 use crate::core::{Failure, Outcome};
 
 use crate::cli::disable::{DisableCommand, DisableTarget};
-use crate::cli::interaction::prompt_alias_or_group;
+use crate::cli::interaction::{InteractionMode, prompt_alias_or_group};
 
 use super::CommandOutcome;
 use super::resource::{ResourceType, resolve_resource_type};
@@ -25,6 +25,7 @@ pub fn handle_disable(
     catalog: &mut AliasCatalog,
     cmd: DisableCommand,
     shell: &ShellType,
+    interaction_mode: InteractionMode,
 ) -> Result<CommandOutcome, Failure> {
     match cmd.target {
         Some(DisableTarget::Alias(args)) => {
@@ -46,7 +47,7 @@ pub fn handle_disable(
                 .as_deref()
                 .expect("clap requires a name when no subcommand is used"),
             shell,
-            |name| prompt_alias_or_group(name, "disabled"),
+            |name| prompt_alias_or_group(interaction_mode, name, "disabled"),
         )
         .map(CommandOutcome::from),
     }
@@ -78,6 +79,7 @@ mod tests {
                 name: Some("ll".to_string()),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -95,6 +97,7 @@ mod tests {
                 name: Some("tools".to_string()),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -114,6 +117,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         let group_result = handle_disable(
             &mut catalog,
@@ -124,6 +128,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(alias_result.is_ok());
@@ -143,6 +148,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert_eq!(

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -1,6 +1,6 @@
 use crate::catalog::types::{Alias, AliasCatalog};
 use crate::cli::edit::EditCommand;
-use crate::cli::interaction::prompt_create_non_existent_group;
+use crate::cli::interaction::{InteractionMode, prompt_create_non_existent_group};
 use crate::core::conflict::conflict_warnings;
 use crate::core::edit::edit_alias;
 use crate::core::{Failure, Outcome};
@@ -25,6 +25,7 @@ pub fn handle_edit(
     catalog: &mut AliasCatalog,
     cmd: EditCommand,
     shell: &ShellType,
+    interaction_mode: InteractionMode,
 ) -> Result<Outcome, Failure> {
     let mut new_alias = Alias::new("".into(), None, true, false); // Default initialization
 
@@ -45,7 +46,9 @@ pub fn handle_edit(
             if let Some(group_name) = &group
                 && !catalog.groups.contains_key(group_name)
             {
-                handle_nonexistent_group(catalog, group_name, prompt_create_non_existent_group)?;
+                handle_nonexistent_group(catalog, group_name, |group| {
+                    prompt_create_non_existent_group(interaction_mode, group)
+                })?;
             }
             new_alias.group = group;
         }
@@ -91,7 +94,12 @@ mod tests {
             toggle_global: false,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
+        let result = handle_edit(
+            &mut catalog,
+            cmd,
+            &ShellType::Bash,
+            InteractionMode::Interactive,
+        );
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edited_command");
@@ -107,7 +115,12 @@ mod tests {
             toggle_global: false,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
+        let result = handle_edit(
+            &mut catalog,
+            cmd,
+            &ShellType::Bash,
+            InteractionMode::Interactive,
+        );
         assert!(result.is_err());
         assert_eq!(result.err(), Some(Failure::AliasDoesNotExist));
     }
@@ -122,7 +135,12 @@ mod tests {
             toggle_global: false,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
+        let result = handle_edit(
+            &mut catalog,
+            cmd,
+            &ShellType::Bash,
+            InteractionMode::Interactive,
+        );
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edit_command");
@@ -139,7 +157,12 @@ mod tests {
             toggle_global: true,
             group: None,
         };
-        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
+        let result = handle_edit(
+            &mut catalog,
+            cmd,
+            &ShellType::Bash,
+            InteractionMode::Interactive,
+        );
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edit_command");
@@ -157,7 +180,12 @@ mod tests {
             toggle_global: false,
             group: Some(Some("dev".into())),
         };
-        let result = handle_edit(&mut catalog, cmd, &ShellType::Bash);
+        let result = handle_edit(
+            &mut catalog,
+            cmd,
+            &ShellType::Bash,
+            InteractionMode::Interactive,
+        );
         assert!(result.is_ok());
         let edited_alias = catalog.aliases.get("test").unwrap();
         assert_eq!(edited_alias.command, "edit_command");

--- a/src/app/enable.rs
+++ b/src/app/enable.rs
@@ -3,7 +3,7 @@ use crate::core::enable::{enable_alias, enable_all, enable_group};
 use crate::core::{Failure, Outcome};
 
 use crate::cli::enable::{EnableCommand, EnableTarget};
-use crate::cli::interaction::prompt_alias_or_group;
+use crate::cli::interaction::{InteractionMode, prompt_alias_or_group};
 
 use super::CommandOutcome;
 use super::resource::{ResourceType, resolve_resource_type};
@@ -25,6 +25,7 @@ pub fn handle_enable(
     catalog: &mut AliasCatalog,
     cmd: EnableCommand,
     shell: &ShellType,
+    interaction_mode: InteractionMode,
 ) -> Result<CommandOutcome, Failure> {
     match cmd.target {
         Some(EnableTarget::Alias(args)) => {
@@ -46,7 +47,7 @@ pub fn handle_enable(
                 .as_deref()
                 .expect("clap requires a name when no subcommand is used"),
             shell,
-            |name| prompt_alias_or_group(name, "enabled"),
+            |name| prompt_alias_or_group(interaction_mode, name, "enabled"),
         )
         .map(CommandOutcome::from),
     }
@@ -78,6 +79,7 @@ mod tests {
                 name: Some("ll".to_string()),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -95,6 +97,7 @@ mod tests {
                 name: Some("tools".to_string()),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -114,6 +117,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         let group_result = handle_enable(
             &mut catalog,
@@ -124,6 +128,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(alias_result.is_ok());
@@ -143,6 +148,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert_eq!(

--- a/src/app/file_path.rs
+++ b/src/app/file_path.rs
@@ -1,4 +1,4 @@
-use crate::cli::interaction::prompt_use_non_existing_catalog_file;
+use crate::cli::interaction::{InteractionMode, prompt_use_non_existing_catalog_file};
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -25,8 +25,10 @@ impl FileType {
     }
 }
 
-pub fn determine_catalog_path() -> Result<Option<PathBuf>> {
-    determine_configured_file_path(FileType::Catalog, prompt_use_non_existing_catalog_file)
+pub fn determine_catalog_path(mode: InteractionMode) -> Result<Option<PathBuf>> {
+    determine_configured_file_path(FileType::Catalog, |path| {
+        prompt_use_non_existing_catalog_file(mode, path)
+    })
 }
 
 fn determine_configured_file_path(
@@ -74,7 +76,7 @@ mod tests {
             CATALOG_FILE_ENV_VAR,
             Some(temp_file.path().to_str().unwrap()),
             || {
-                let result = determine_catalog_path().unwrap();
+                let result = determine_catalog_path(InteractionMode::Interactive).unwrap();
                 assert_eq!(result, Some(temp_file.path().to_path_buf()));
             },
         );
@@ -113,7 +115,7 @@ mod tests {
     #[test]
     fn test_determine_catalog_path_env_var_not_set() {
         with_var(CATALOG_FILE_ENV_VAR, None as Option<&str>, || {
-            let result = determine_catalog_path().unwrap();
+            let result = determine_catalog_path(InteractionMode::Interactive).unwrap();
             assert_eq!(result, None);
         });
     }

--- a/src/app/move.rs
+++ b/src/app/move.rs
@@ -5,21 +5,24 @@ use crate::core::r#move::move_alias;
 
 use crate::catalog::types::AliasCatalog;
 
-use crate::cli::interaction::prompt_create_non_existent_group;
+use crate::cli::interaction::{InteractionMode, prompt_create_non_existent_group};
 use crate::cli::r#move::MoveCommand;
 
 use log::{debug, error, info};
 
-pub fn handle_move(catalog: &mut AliasCatalog, cmd: MoveCommand) -> Result<Outcome, Failure> {
+pub fn handle_move(
+    catalog: &mut AliasCatalog,
+    cmd: MoveCommand,
+    interaction_mode: InteractionMode,
+) -> Result<Outcome, Failure> {
     match move_alias(catalog, &cmd.name, &cmd.new_group) {
         Ok(outcome) => Ok(outcome),
         Err(e) => match e {
-            Failure::GroupDoesNotExist => handle_non_existing_group(
-                catalog,
-                &cmd.name,
-                &cmd.new_group.unwrap(),
-                prompt_create_non_existent_group,
-            ),
+            Failure::GroupDoesNotExist => {
+                handle_non_existing_group(catalog, &cmd.name, &cmd.new_group.unwrap(), |group| {
+                    prompt_create_non_existent_group(interaction_mode, group)
+                })
+            }
             Failure::AliasDoesNotExist => {
                 error!("Alias '{}' does not exist", cmd.name);
                 Err(e)
@@ -96,7 +99,7 @@ mod tests {
             name: "ll".into(),
             new_group: Some("utilities".into()),
         };
-        let outcome = handle_move(&mut catalog, cmd).unwrap();
+        let outcome = handle_move(&mut catalog, cmd, InteractionMode::Interactive).unwrap();
         assert_matches!(outcome, Outcome::CatalogChanged);
         assert_eq!(
             catalog.aliases.get("ll"),
@@ -116,7 +119,7 @@ mod tests {
             name: "nonexistent".into(),
             new_group: Some("utilities".into()),
         };
-        let result = handle_move(&mut catalog, cmd);
+        let result = handle_move(&mut catalog, cmd, InteractionMode::Interactive);
         assert_matches!(result, Err(Failure::AliasDoesNotExist));
         assert!(!catalog.aliases.contains_key("nonexistent"));
         assert!(!catalog.groups.contains_key("utilities"));

--- a/src/app/remove.rs
+++ b/src/app/remove.rs
@@ -8,8 +8,8 @@ use crate::core::{Failure, Outcome};
 use super::shell::ShellType;
 
 use crate::cli::interaction::{
-    prompt_alias_or_group, prompt_confirm_remove_all, prompt_enable_reassigned_aliases,
-    prompt_reassign_group_aliases,
+    InteractionMode, prompt_alias_or_group, prompt_confirm_remove_all,
+    prompt_enable_reassigned_aliases, prompt_reassign_group_aliases,
 };
 
 use crate::cli::remove::{RemoveCommand, RemoveTarget};
@@ -113,6 +113,7 @@ pub fn handle_remove(
     catalog: &mut AliasCatalog,
     cmd: RemoveCommand,
     shell: &ShellType,
+    interaction_mode: InteractionMode,
 ) -> Result<Outcome, Failure> {
     match cmd.target {
         Some(RemoveTarget::Alias(args)) => remove_alias(catalog, &args.name),
@@ -130,19 +131,21 @@ pub fn handle_remove(
                 args.reassign,
                 shell,
                 reassigned_alias_action,
-                prompt_enable_reassigned_aliases,
+                |name, count| prompt_enable_reassigned_aliases(interaction_mode, name, count),
             )
         }
-        Some(RemoveTarget::All) => handle_remove_all(catalog, shell, prompt_confirm_remove_all),
+        Some(RemoveTarget::All) => handle_remove_all(catalog, shell, || {
+            prompt_confirm_remove_all(interaction_mode)
+        }),
         None => handle_remove_shorthand(
             catalog,
             cmd.name
                 .as_deref()
                 .expect("clap requires a name when no subcommand is used"),
             shell,
-            |name| prompt_alias_or_group(name, "removed"),
-            prompt_reassign_group_aliases,
-            prompt_enable_reassigned_aliases,
+            |name| prompt_alias_or_group(interaction_mode, name, "removed"),
+            |name| prompt_reassign_group_aliases(interaction_mode, name),
+            |name, count| prompt_enable_reassigned_aliases(interaction_mode, name, count),
         ),
     }
 }
@@ -180,6 +183,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_ok());
         assert!(!catalog.aliases.contains_key("ls"));
@@ -199,6 +203,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert_matches!(result.err(), Some(Failure::AliasDoesNotExist));
     }
@@ -218,6 +223,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert_eq!(result.unwrap(), Outcome::CatalogChanged);
         assert!(!catalog.groups.contains_key("files"));
@@ -238,6 +244,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert_matches!(result.err(), Some(Failure::GroupDoesNotExist));
     }
@@ -257,6 +264,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_ok());
         assert!(!catalog.aliases.contains_key("rm"));
@@ -278,6 +286,7 @@ mod tests {
                 name: None,
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
         assert!(result.is_ok());
         assert!(!catalog.groups.contains_key("files"));
@@ -339,6 +348,7 @@ mod tests {
                 name: Some("rm".to_string()),
             },
             &ShellType::Bash,
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());

--- a/src/app/rename.rs
+++ b/src/app/rename.rs
@@ -1,5 +1,5 @@
 use crate::catalog::types::AliasCatalog;
-use crate::cli::interaction::prompt_alias_or_group;
+use crate::cli::interaction::{InteractionMode, prompt_alias_or_group};
 use crate::cli::rename::{RenameCommand, RenameTarget};
 use crate::core::rename::{rename_alias, rename_group};
 use crate::core::{Failure, Outcome};
@@ -19,7 +19,11 @@ fn handle_rename_shorthand(
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn handle_rename(catalog: &mut AliasCatalog, cmd: RenameCommand) -> Result<Outcome, Failure> {
+pub fn handle_rename(
+    catalog: &mut AliasCatalog,
+    cmd: RenameCommand,
+    interaction_mode: InteractionMode,
+) -> Result<Outcome, Failure> {
     match cmd.target {
         Some(RenameTarget::Alias(args)) => rename_alias(catalog, &args.old_name, &args.new_name),
         Some(RenameTarget::Group(args)) => rename_group(catalog, &args.old_name, &args.new_name),
@@ -31,7 +35,7 @@ pub fn handle_rename(catalog: &mut AliasCatalog, cmd: RenameCommand) -> Result<O
             cmd.new_name
                 .as_deref()
                 .expect("clap requires a new name when no subcommand is used"),
-            |name| prompt_alias_or_group(name, "renamed"),
+            |name| prompt_alias_or_group(interaction_mode, name, "renamed"),
         ),
     }
 }
@@ -62,6 +66,7 @@ mod tests {
                 old_name: Some("ll".to_string()),
                 new_name: Some("list".to_string()),
             },
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -80,6 +85,7 @@ mod tests {
                 old_name: Some("tools".to_string()),
                 new_name: Some("commands".to_string()),
             },
+            InteractionMode::Interactive,
         );
 
         assert!(result.is_ok());
@@ -101,6 +107,7 @@ mod tests {
                 old_name: None,
                 new_name: None,
             },
+            InteractionMode::Interactive,
         );
         let group_result = handle_rename(
             &mut catalog,
@@ -112,6 +119,7 @@ mod tests {
                 old_name: None,
                 new_name: None,
             },
+            InteractionMode::Interactive,
         );
 
         assert!(alias_result.is_ok());

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -1,5 +1,6 @@
 use super::shell::ShellType;
 use crate::catalog::types::AliasCatalog;
+use crate::cli::interaction::InteractionMode;
 use crate::cli::sync::{ShellSyncCommand, SyncCommand};
 use crate::core::sync::{
     CATALOG_REVISION_ENV_VAR, MANAGED_ALIASES_ENV_VAR, generate_reconciliation_script,
@@ -16,7 +17,7 @@ pub fn handle_shell_sync(
     catalog: &AliasCatalog,
     shell: &ShellType,
     cmd: ShellSyncCommand,
-    force: bool,
+    interaction_mode: InteractionMode,
 ) -> String {
     let managed_aliases = std::env::var(MANAGED_ALIASES_ENV_VAR).unwrap_or_default();
     let applied_revision = std::env::var(CATALOG_REVISION_ENV_VAR).unwrap_or_default();
@@ -26,7 +27,7 @@ pub fn handle_shell_sync(
         shell,
         &managed_aliases,
         &applied_revision,
-        cmd.if_changed && !force,
+        cmd.if_changed && interaction_mode != InteractionMode::Force,
     )
 }
 
@@ -55,7 +56,7 @@ mod tests {
                     &catalog,
                     &ShellType::Bash,
                     ShellSyncCommand { if_changed: true },
-                    false,
+                    InteractionMode::Interactive,
                 );
                 assert!(script.contains("unalias -- 'old'"));
                 assert!(script.contains("alias -- 'current=echo current'"));

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -16,6 +16,7 @@ pub fn handle_shell_sync(
     catalog: &AliasCatalog,
     shell: &ShellType,
     cmd: ShellSyncCommand,
+    force: bool,
 ) -> String {
     let managed_aliases = std::env::var(MANAGED_ALIASES_ENV_VAR).unwrap_or_default();
     let applied_revision = std::env::var(CATALOG_REVISION_ENV_VAR).unwrap_or_default();
@@ -25,7 +26,7 @@ pub fn handle_shell_sync(
         shell,
         &managed_aliases,
         &applied_revision,
-        cmd.if_changed && !cmd.force,
+        cmd.if_changed && !force,
     )
 }
 
@@ -53,10 +54,8 @@ mod tests {
                 let script = handle_shell_sync(
                     &catalog,
                     &ShellType::Bash,
-                    ShellSyncCommand {
-                        if_changed: true,
-                        force: false,
-                    },
+                    ShellSyncCommand { if_changed: true },
+                    false,
                 );
                 assert!(script.contains("unalias -- 'old'"));
                 assert!(script.contains("alias -- 'current=echo current'"));

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -153,6 +153,12 @@ mod tests {
     use super::*;
 
     #[test]
+    fn interactive_mode_does_not_supply_an_answer() {
+        configure_interaction(false, false);
+        assert_eq!(non_interactive_answer("continue"), None);
+    }
+
+    #[test]
     fn builds_alias_or_group_select() {
         drop(alias_or_group_select("tools", "enabled"));
     }

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -1,7 +1,40 @@
 use dialoguer::{Confirm, Select};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const INTERACTIVE: u8 = 0;
+const FORCE: u8 = 1;
+const NO_INPUT: u8 = 2;
+const INPUT_REQUIRED_EXIT_CODE: i32 = 2;
+
+static INTERACTION_MODE: AtomicU8 = AtomicU8::new(INTERACTIVE);
+
+pub fn configure_interaction(force: bool, no_input: bool) {
+    let mode = if force {
+        FORCE
+    } else if no_input {
+        NO_INPUT
+    } else {
+        INTERACTIVE
+    };
+    INTERACTION_MODE.store(mode, Ordering::Relaxed);
+}
+
+fn non_interactive_answer(prompt: &str) -> Option<bool> {
+    match INTERACTION_MODE.load(Ordering::Relaxed) {
+        FORCE => Some(true),
+        NO_INPUT => {
+            eprintln!("ERROR: Input required to {prompt}; --no-input was supplied.");
+            std::process::exit(INPUT_REQUIRED_EXIT_CODE);
+        }
+        _ => None,
+    }
+}
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_overwrite_existing_alias(alias: &str) -> bool {
+    if let Some(answer) = non_interactive_answer("overwrite an existing alias") {
+        return answer;
+    }
     Confirm::new()
         .with_prompt(format!(
             "Alias \"{}\" already exists. Do you want to overwrite it?",
@@ -14,6 +47,9 @@ pub fn prompt_overwrite_existing_alias(alias: &str) -> bool {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_create_non_existent_group(group: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(&format!("create missing group '{group}'")) {
+        return answer;
+    }
     Confirm::new()
         .with_prompt(format!(
             "Group '{}' does not exist. Do you want to create it?",
@@ -26,6 +62,9 @@ pub fn prompt_create_non_existent_group(group: &str) -> bool {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_use_non_existing_catalog_file(path: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(&format!("use missing catalog path '{path}'")) {
+        return answer;
+    }
     Confirm::new()
         .with_prompt(format!(
             "Catalog file '{}' does not exist. Do you want to use this path anyway?",
@@ -38,6 +77,9 @@ pub fn prompt_use_non_existing_catalog_file(path: &str) -> bool {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_confirm_remove_all() -> bool {
+    if let Some(answer) = non_interactive_answer("remove all aliases and groups") {
+        return answer;
+    }
     Confirm::new()
         .with_prompt("Are you sure you want to remove all aliases and groups?")
         .default(false)
@@ -47,6 +89,11 @@ pub fn prompt_confirm_remove_all() -> bool {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_alias_or_group(name: &str, action: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(&format!(
+        "choose whether alias or group '{name}' should be {action}"
+    )) {
+        return answer;
+    }
     alias_or_group_select(name, action).interact().unwrap() == 0
 }
 
@@ -62,11 +109,19 @@ fn alias_or_group_select(name: &str, action: &str) -> Select<'static> {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_reassign_group_aliases(name: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(&format!("reassign aliases from group '{name}'")) {
+        return answer;
+    }
     reassign_group_confirm(name).interact().unwrap()
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_enable_reassigned_aliases(name: &str, alias_count: usize) -> bool {
+    if let Some(answer) = non_interactive_answer(&format!(
+        "enable aliases reassigned from disabled group '{name}'"
+    )) {
+        return answer;
+    }
     enable_reassigned_aliases_confirm(name, alias_count)
         .interact()
         .unwrap()

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -1,38 +1,28 @@
 use dialoguer::{Confirm, Select};
-use std::sync::atomic::{AtomicU8, Ordering};
 
-const INTERACTIVE: u8 = 0;
-const FORCE: u8 = 1;
-const NO_INPUT: u8 = 2;
 const INPUT_REQUIRED_EXIT_CODE: i32 = 2;
 
-static INTERACTION_MODE: AtomicU8 = AtomicU8::new(INTERACTIVE);
-
-pub fn configure_interaction(force: bool, no_input: bool) {
-    let mode = if force {
-        FORCE
-    } else if no_input {
-        NO_INPUT
-    } else {
-        INTERACTIVE
-    };
-    INTERACTION_MODE.store(mode, Ordering::Relaxed);
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InteractionMode {
+    Interactive,
+    Force,
+    NoInput,
 }
 
-fn non_interactive_answer(prompt: &str) -> Option<bool> {
-    match INTERACTION_MODE.load(Ordering::Relaxed) {
-        FORCE => Some(true),
-        NO_INPUT => {
+fn non_interactive_answer(mode: InteractionMode, prompt: &str) -> Option<bool> {
+    match mode {
+        InteractionMode::Force => Some(true),
+        InteractionMode::NoInput => {
             eprintln!("ERROR: Input required to {prompt}; --no-input was supplied.");
             std::process::exit(INPUT_REQUIRED_EXIT_CODE);
         }
-        _ => None,
+        InteractionMode::Interactive => None,
     }
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_overwrite_existing_alias(alias: &str) -> bool {
-    if let Some(answer) = non_interactive_answer("overwrite an existing alias") {
+pub fn prompt_overwrite_existing_alias(mode: InteractionMode, alias: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(mode, "overwrite an existing alias") {
         return answer;
     }
     Confirm::new()
@@ -46,8 +36,8 @@ pub fn prompt_overwrite_existing_alias(alias: &str) -> bool {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_create_non_existent_group(group: &str) -> bool {
-    if let Some(answer) = non_interactive_answer(&format!("create missing group '{group}'")) {
+pub fn prompt_create_non_existent_group(mode: InteractionMode, group: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(mode, &format!("create missing group '{group}'")) {
         return answer;
     }
     Confirm::new()
@@ -61,8 +51,10 @@ pub fn prompt_create_non_existent_group(group: &str) -> bool {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_use_non_existing_catalog_file(path: &str) -> bool {
-    if let Some(answer) = non_interactive_answer(&format!("use missing catalog path '{path}'")) {
+pub fn prompt_use_non_existing_catalog_file(mode: InteractionMode, path: &str) -> bool {
+    if let Some(answer) =
+        non_interactive_answer(mode, &format!("use missing catalog path '{path}'"))
+    {
         return answer;
     }
     Confirm::new()
@@ -76,8 +68,8 @@ pub fn prompt_use_non_existing_catalog_file(path: &str) -> bool {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_confirm_remove_all() -> bool {
-    if let Some(answer) = non_interactive_answer("remove all aliases and groups") {
+pub fn prompt_confirm_remove_all(mode: InteractionMode) -> bool {
+    if let Some(answer) = non_interactive_answer(mode, "remove all aliases and groups") {
         return answer;
     }
     Confirm::new()
@@ -88,10 +80,11 @@ pub fn prompt_confirm_remove_all() -> bool {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_alias_or_group(name: &str, action: &str) -> bool {
-    if let Some(answer) = non_interactive_answer(&format!(
-        "choose whether alias or group '{name}' should be {action}"
-    )) {
+pub fn prompt_alias_or_group(mode: InteractionMode, name: &str, action: &str) -> bool {
+    if let Some(answer) = non_interactive_answer(
+        mode,
+        &format!("choose whether alias or group '{name}' should be {action}"),
+    ) {
         return answer;
     }
     alias_or_group_select(name, action).interact().unwrap() == 0
@@ -108,18 +101,25 @@ fn alias_or_group_select(name: &str, action: &str) -> Select<'static> {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_reassign_group_aliases(name: &str) -> bool {
-    if let Some(answer) = non_interactive_answer(&format!("reassign aliases from group '{name}'")) {
+pub fn prompt_reassign_group_aliases(mode: InteractionMode, name: &str) -> bool {
+    if let Some(answer) =
+        non_interactive_answer(mode, &format!("reassign aliases from group '{name}'"))
+    {
         return answer;
     }
     reassign_group_confirm(name).interact().unwrap()
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_enable_reassigned_aliases(name: &str, alias_count: usize) -> bool {
-    if let Some(answer) = non_interactive_answer(&format!(
-        "enable aliases reassigned from disabled group '{name}'"
-    )) {
+pub fn prompt_enable_reassigned_aliases(
+    mode: InteractionMode,
+    name: &str,
+    alias_count: usize,
+) -> bool {
+    if let Some(answer) = non_interactive_answer(
+        mode,
+        &format!("enable aliases reassigned from disabled group '{name}'"),
+    ) {
         return answer;
     }
     enable_reassigned_aliases_confirm(name, alias_count)
@@ -154,8 +154,10 @@ mod tests {
 
     #[test]
     fn interactive_mode_does_not_supply_an_answer() {
-        configure_interaction(false, false);
-        assert_eq!(non_interactive_answer("continue"), None);
+        assert_eq!(
+            non_interactive_answer(InteractionMode::Interactive, "continue"),
+            None
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
 
 pub(crate) mod add;
 pub(crate) mod disable;
@@ -36,6 +36,14 @@ use sync::{ShellSyncCommand, SyncCommand};
     disable_help_subcommand = true
 )]
 pub struct Cli {
+    /// Accept every prompt and force applicable operations
+    #[arg(long, global = true, conflicts_with = "no_input")]
+    pub force: bool,
+
+    /// Fail instead of requesting interactive input
+    #[arg(long, global = true, conflicts_with = "force")]
+    pub no_input: bool,
+
     /// Increase output verbosity
     #[arg(
         short,
@@ -65,6 +73,24 @@ pub struct Cli {
     /// Subcommands
     #[command(subcommand)]
     pub command: Commands,
+}
+
+impl Cli {
+    pub fn validate_prompt_controls(&self) -> Result<(), clap::Error> {
+        if self.force && self.no_input {
+            return Err(Self::command().error(
+                ErrorKind::ArgumentConflict,
+                "--force cannot be used with --no-input",
+            ));
+        }
+        if self.force && matches!(&self.command, Commands::ShellSync(cmd) if cmd.if_changed) {
+            return Err(Self::command().error(
+                ErrorKind::ArgumentConflict,
+                "--force cannot be used with --if-changed",
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Subcommand)]
@@ -432,11 +458,49 @@ mod tests {
     fn parses_internal_conditional_shell_sync() {
         let cli = Cli::try_parse_from(["aliasmgr", "shell-sync", "--if-changed"])
             .expect("internal shell sync should parse");
+        assert!(!cli.force);
         let Commands::ShellSync(cmd) = cli.command else {
             panic!("expected shell sync command");
         };
         assert!(cmd.if_changed);
-        assert!(!cmd.force);
+    }
+
+    #[test]
+    fn parses_global_prompt_controls() {
+        let force = Cli::try_parse_from(["aliasmgr", "add", "ll", "ls -l", "--force"])
+            .expect("force should parse after a subcommand");
+        assert!(force.force);
+        assert!(!force.no_input);
+
+        let no_input = Cli::try_parse_from(["aliasmgr", "--no-input", "remove", "all"])
+            .expect("no-input should parse before a subcommand");
+        assert!(!no_input.force);
+        assert!(no_input.no_input);
+    }
+
+    #[test]
+    fn prompt_controls_conflict() {
+        let cli = Cli::try_parse_from(["aliasmgr", "--force", "remove", "all", "--no-input"])
+            .expect("global options in different command scopes should parse before validation");
+        assert!(cli.validate_prompt_controls().is_err());
+    }
+
+    #[test]
+    fn global_force_preserves_forced_shell_sync() {
+        let cli = Cli::try_parse_from(["aliasmgr", "shell-sync", "--force"])
+            .expect("forced internal shell sync should parse");
+        assert!(cli.force);
+        let Commands::ShellSync(cmd) = cli.command else {
+            panic!("expected shell sync command");
+        };
+        assert!(!cmd.if_changed);
+    }
+
+    #[test]
+    fn global_force_conflicts_with_conditional_shell_sync() {
+        let cli = Cli::try_parse_from(["aliasmgr", "--force", "shell-sync", "--if-changed"])
+            .expect("global options in different command scopes should parse before validation");
+        assert!(cli.validate_prompt_controls().is_err());
     }
 
     #[test]

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -8,8 +8,4 @@ pub struct ShellSyncCommand {
     /// Skip reconciliation when this terminal already has the current revision
     #[arg(long, conflicts_with = "force")]
     pub if_changed: bool,
-
-    /// Reconcile even when this terminal already has the current revision
-    #[arg(long, conflicts_with = "if_changed")]
-    pub force: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod core;
 
 use clap::Parser;
 
-use cli::interaction::configure_interaction;
+use cli::interaction::InteractionMode;
 use cli::{Cli, Commands};
 
 use catalog::io::{catalog_path as resolve_catalog_path, load_catalog, save_catalog};
@@ -41,8 +41,13 @@ fn main() {
         error.exit();
     }
     let quiet = cli.quiet;
-    let force = cli.force;
-    configure_interaction(force, cli.no_input);
+    let interaction_mode = if cli.force {
+        InteractionMode::Force
+    } else if cli.no_input {
+        InteractionMode::NoInput
+    } else {
+        InteractionMode::Interactive
+    };
 
     // Determine log level based on CLI flags
     let level = if cli.quiet {
@@ -72,7 +77,7 @@ fn main() {
         shell = determine_shell();
         debug!("Determined shell: {}", shell);
 
-        catalog_path = determine_catalog_path()
+        catalog_path = determine_catalog_path(interaction_mode)
             .expect("Custom catalog path did not exist and user chose not to use it.");
         debug!("Using catalog path: {:?}", catalog_path);
 
@@ -93,21 +98,34 @@ fn main() {
 
     let result = match cli.command {
         // Add new alias or group
-        Commands::Add(cmd) => handle_add(&mut catalog, cmd, &shell).map(CommandOutcome::from),
-        Commands::Remove(cmd) => handle_remove(&mut catalog, cmd, &shell).map(CommandOutcome::from),
-        Commands::Move(cmd) => handle_move(&mut catalog, cmd).map(CommandOutcome::from),
+        Commands::Add(cmd) => {
+            handle_add(&mut catalog, cmd, &shell, interaction_mode).map(CommandOutcome::from)
+        }
+        Commands::Remove(cmd) => {
+            handle_remove(&mut catalog, cmd, &shell, interaction_mode).map(CommandOutcome::from)
+        }
+        Commands::Move(cmd) => {
+            handle_move(&mut catalog, cmd, interaction_mode).map(CommandOutcome::from)
+        }
         Commands::List(cmd) => handle_list(&catalog, cmd, &shell).map(CommandOutcome::from),
-        Commands::Rename(cmd) => handle_rename(&mut catalog, cmd).map(CommandOutcome::from),
-        Commands::Edit(cmd) => handle_edit(&mut catalog, cmd, &shell).map(CommandOutcome::from),
+        Commands::Rename(cmd) => {
+            handle_rename(&mut catalog, cmd, interaction_mode).map(CommandOutcome::from)
+        }
+        Commands::Edit(cmd) => {
+            handle_edit(&mut catalog, cmd, &shell, interaction_mode).map(CommandOutcome::from)
+        }
         Commands::Sort(cmd) => handle_sort(&mut catalog, cmd).map(CommandOutcome::from),
-        Commands::Enable(cmd) => handle_enable(&mut catalog, cmd, &shell),
-        Commands::Disable(cmd) => handle_disable(&mut catalog, cmd, &shell),
+        Commands::Enable(cmd) => handle_enable(&mut catalog, cmd, &shell, interaction_mode),
+        Commands::Disable(cmd) => handle_disable(&mut catalog, cmd, &shell, interaction_mode),
         Commands::Doctor(cmd) => {
             handle_doctor(&catalog, cmd, &shell, quiet).map(CommandOutcome::from)
         }
         Commands::Sync(cmd) => handle_sync(cmd).map(CommandOutcome::from),
         Commands::ShellSync(cmd) => {
-            print!("{}", handle_shell_sync(&catalog, &shell, cmd, force));
+            print!(
+                "{}",
+                handle_shell_sync(&catalog, &shell, cmd, interaction_mode)
+            );
             Ok(CommandOutcome::from(Outcome::NoChanges))
         }
         Commands::Init(cmd) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod core;
 
 use clap::Parser;
 
+use cli::interaction::configure_interaction;
 use cli::{Cli, Commands};
 
 use catalog::io::{catalog_path as resolve_catalog_path, load_catalog, save_catalog};
@@ -36,7 +37,12 @@ use log::{LevelFilter, debug};
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn main() {
     let cli = Cli::parse();
+    if let Err(error) = cli.validate_prompt_controls() {
+        error.exit();
+    }
     let quiet = cli.quiet;
+    let force = cli.force;
+    configure_interaction(force, cli.no_input);
 
     // Determine log level based on CLI flags
     let level = if cli.quiet {
@@ -101,7 +107,7 @@ fn main() {
         }
         Commands::Sync(cmd) => handle_sync(cmd).map(CommandOutcome::from),
         Commands::ShellSync(cmd) => {
-            print!("{}", handle_shell_sync(&catalog, &shell, cmd));
+            print!("{}", handle_shell_sync(&catalog, &shell, cmd, force));
             Ok(CommandOutcome::from(Outcome::NoChanges))
         }
         Commands::Init(cmd) => {

--- a/tests/non_interactive.rs
+++ b/tests/non_interactive.rs
@@ -140,6 +140,67 @@ fn force_accepts_reassignment_and_enabling_prompts() {
 }
 
 #[test]
+fn force_propagates_through_prompting_command_handlers() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+
+    for (args, expected_alias) in [
+        (
+            vec!["edit", "ll", "ls -la", "--group", "tools", "--force"],
+            "ll = \"ls -la\"",
+        ),
+        (vec!["move", "ll", "tools", "--force"], "ll = \"ls\""),
+    ] {
+        fs::write(&catalog, "ll = \"ls\"\n").unwrap();
+        let output = run_aliasmgr(&catalog, &args);
+        assert!(output.status.success(), "command failed: {output:?}");
+        let content = fs::read_to_string(&catalog).unwrap();
+        assert!(content.contains("[tools]"));
+        assert!(
+            content.contains(expected_alias),
+            "catalog {content:?} did not contain {expected_alias:?}"
+        );
+    }
+
+    for (enabled, command) in [(false, "enable"), (true, "disable")] {
+        fs::write(
+            &catalog,
+            format!(
+                "[tools]\nenabled = false\n\"aliasmgr ungrouped alias\" = \
+                 {{ command = \"echo tools\", enabled = {enabled} }}\n"
+            ),
+        )
+        .unwrap();
+        let output = run_aliasmgr(&catalog, &[command, "tools", "--force"]);
+        assert!(output.status.success(), "command failed: {output:?}");
+        let content = fs::read_to_string(&catalog).unwrap();
+        let expected_alias = format!(
+            "\"aliasmgr ungrouped alias\" = {{ command = \"echo tools\", enabled = {}, global = false }}",
+            command == "enable"
+        );
+        assert!(
+            content.contains(&expected_alias),
+            "catalog {content:?} did not contain {expected_alias:?}"
+        );
+    }
+
+    fs::write(
+        &catalog,
+        "[tools]\nenabled = false\nbuild = \"cargo build\"\n",
+    )
+    .unwrap();
+    let output = run_aliasmgr(
+        &catalog,
+        &["remove", "group", "tools", "--reassign", "--force"],
+    );
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert_eq!(
+        fs::read_to_string(&catalog).unwrap(),
+        "build = \"cargo build\"\n"
+    );
+}
+
+#[test]
 fn force_and_no_input_conflict_across_command_scopes() {
     let directory = tempfile::tempdir().unwrap();
     let catalog = directory.path().join("aliases.toml");

--- a/tests/non_interactive.rs
+++ b/tests/non_interactive.rs
@@ -1,0 +1,161 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_aliasmgr(catalog: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(args)
+        .env("ALIASMGR_CATALOG_PATH", catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .output()
+        .expect("aliasmgr command should run")
+}
+
+fn assert_input_required(output: &Output, action: &str) {
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERROR: Input required to"));
+    assert!(
+        stderr.contains(action),
+        "stderr {stderr:?} did not contain {action:?}"
+    );
+    assert!(stderr.contains("--no-input was supplied"));
+}
+
+#[test]
+fn force_accepts_overwrite_missing_group_and_remove_all() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "ll = \"ls\"\n").unwrap();
+
+    let overwrite = run_aliasmgr(&catalog, &["add", "ll", "ls -la", "--force"]);
+    assert!(overwrite.status.success());
+    assert!(
+        fs::read_to_string(&catalog)
+            .unwrap()
+            .contains("ll = \"ls -la\"")
+    );
+
+    let missing_group = run_aliasmgr(
+        &catalog,
+        &[
+            "add",
+            "build",
+            "cargo build",
+            "--group",
+            "development",
+            "--force",
+        ],
+    );
+    assert!(missing_group.status.success());
+    let content = fs::read_to_string(&catalog).unwrap();
+    assert!(content.contains("[development]"));
+    assert!(content.contains("build = \"cargo build\""));
+
+    let remove_all = run_aliasmgr(&catalog, &["remove", "all", "--force"]);
+    assert!(remove_all.status.success());
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), "");
+}
+
+#[test]
+fn no_input_fails_overwrite_missing_group_and_remove_all_without_changes() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+
+    for (content, args, action) in [
+        (
+            "ll = \"ls\"\n",
+            vec!["add", "ll", "ls -la", "--no-input"],
+            "overwrite an existing alias",
+        ),
+        (
+            "ll = \"ls\"\n",
+            vec![
+                "add",
+                "build",
+                "cargo build",
+                "--group",
+                "development",
+                "--no-input",
+            ],
+            "create missing group 'development'",
+        ),
+        (
+            "ll = \"ls\"\n",
+            vec!["remove", "all", "--no-input"],
+            "remove all aliases and groups",
+        ),
+    ] {
+        fs::write(&catalog, content).unwrap();
+        let output = run_aliasmgr(&catalog, &args);
+        assert_input_required(&output, action);
+        assert_eq!(fs::read_to_string(&catalog).unwrap(), content);
+    }
+}
+
+#[test]
+fn prompt_controls_cover_missing_catalogs_and_resource_choices() {
+    let directory = tempfile::tempdir().unwrap();
+    let missing_catalog = directory.path().join("missing.toml");
+
+    let no_input = run_aliasmgr(&missing_catalog, &["add", "group", "tools", "--no-input"]);
+    assert_input_required(&no_input, "use missing catalog path");
+    assert!(!missing_catalog.exists());
+
+    let force = run_aliasmgr(&missing_catalog, &["add", "group", "tools", "--force"]);
+    assert!(force.status.success());
+    assert!(
+        fs::read_to_string(&missing_catalog)
+            .unwrap()
+            .contains("[tools]")
+    );
+
+    fs::write(
+        &missing_catalog,
+        "[tools]\n\"aliasmgr ungrouped alias\" = \"echo tools\"\n",
+    )
+    .unwrap();
+    let remove_alias = run_aliasmgr(&missing_catalog, &["remove", "tools", "--force"]);
+    assert!(remove_alias.status.success());
+    assert_eq!(fs::read_to_string(&missing_catalog).unwrap(), "[tools]\n");
+}
+
+#[test]
+fn force_accepts_reassignment_and_enabling_prompts() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(
+        &catalog,
+        "[tools]\nenabled = false\nbuild = \"cargo build\"\n",
+    )
+    .unwrap();
+
+    let output = run_aliasmgr(&catalog, &["remove", "tools", "--force"]);
+
+    assert!(output.status.success());
+    assert_eq!(
+        fs::read_to_string(&catalog).unwrap(),
+        "build = \"cargo build\"\n"
+    );
+}
+
+#[test]
+fn force_and_no_input_conflict_across_command_scopes() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "").unwrap();
+
+    let output = run_aliasmgr(&catalog, &["--force", "list", "--no-input"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--force cannot be used with --no-input")
+    );
+
+    let shell_sync = run_aliasmgr(&catalog, &["--force", "shell-sync", "--if-changed"]);
+    assert_eq!(shell_sync.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&shell_sync.stderr)
+            .contains("--force cannot be used with --if-changed")
+    );
+}


### PR DESCRIPTION
## Summary

- add mutually exclusive global `--force` and `--no-input` prompt controls
- make `--force` accept confirmations and choose aliases for alias/group collisions
- make `--no-input` report the required action and exit with status 2 without changing the catalog
- preserve default interactive behavior and forced internal shell synchronization

## Acceptance criteria

- Commands can run without TTY interaction by using `--force`.
- Scripts can prohibit interaction with `--no-input` and receive exit status 2 only when input is required.
- Overwrite, missing-group, missing-catalog, remove-all, resource-selection, and reassignment prompts share the same predictable policy.
- Existing interactive behavior remains unchanged when neither flag is supplied.
- README documentation describes both flags, their conflict, and exit behavior.

## Validation

- `cargo build --verbose`
- `cargo test --verbose` (239 unit and 25 integration tests passed)
- `cargo clippy`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo +nightly llvm-cov --all-features --workspace --lcov` in a clean disposable worktree (264 tests passed)

Closes #7
