### PR TITLE
Add bulk alias operations by pattern or group filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ ll = { command = "ls -la", enabled = true }
 - `aliasmgr list [<pattern>] [--group [group]] [--enabled] [--disabled] [--global] [--format <human|json>]`
 - `aliasmgr remove <name>` (removes the matching alias or group; prompts if both exist)
 - `aliasmgr remove alias <name>` (explicit form)
+- `aliasmgr remove alias [--pattern <glob>] [--group [group]]` (bulk filter; prompts once)
 - `aliasmgr remove group <name> [--reassign [--enable-reassigned | --disable-reassigned]]`
 - `aliasmgr remove all`
 - `aliasmgr rename <old_name> <new_name>` (renames the matching alias or group; prompts if both exist)
@@ -66,10 +67,12 @@ ll = { command = "ls -la", enabled = true }
 - `aliasmgr sort groups`
 - `aliasmgr enable <name>` (enables the matching alias or group; prompts if both exist)
 - `aliasmgr enable alias <name>` (explicit form)
+- `aliasmgr enable alias [--pattern <glob>] [--group [group]]` (bulk filter)
 - `aliasmgr enable group <name>`
 - `aliasmgr enable all`
 - `aliasmgr disable <name>` (disables the matching alias or group; prompts if both exist)
 - `aliasmgr disable alias <name>` (explicit form)
+- `aliasmgr disable alias [--pattern <glob>] [--group [group]]` (bulk filter)
 - `aliasmgr disable group <name>`
 - `aliasmgr disable all`
 - `aliasmgr doctor` (also available as `aliasmgr validate`)
@@ -90,6 +93,10 @@ Notes:
   global aliases and command conflicts are warnings. Errors produce a non-zero exit
   status for scripts.
 - `list --format json` emits an array of aliases with `name`, `command`, `group`, `enabled`, and `global` fields. Ungrouped aliases have a `null` group.
+- Alias filter operations match alias names with glob syntax. `--group <group>`
+  selects aliases in that exact group, while a bare `--group` selects ungrouped
+  aliases. Combining `--pattern` and `--group` selects their intersection and
+  never changes the group itself.
 
 ## Sync Behavior
 - Each initialized terminal tracks the alias names and effective catalog revision that it last applied.

--- a/src/app/disable.rs
+++ b/src/app/disable.rs
@@ -1,5 +1,6 @@
 use crate::catalog::types::AliasCatalog;
-use crate::core::disable::{disable_alias, disable_all, disable_group};
+use crate::core::disable::{disable_alias, disable_aliases, disable_all, disable_group};
+use crate::core::selector::select_aliases;
 use crate::core::{Failure, Outcome};
 
 use crate::cli::disable::{DisableCommand, DisableTarget};
@@ -28,9 +29,28 @@ pub fn handle_disable(
     interaction_mode: InteractionMode,
 ) -> Result<CommandOutcome, Failure> {
     match cmd.target {
-        Some(DisableTarget::Alias(args)) => {
-            disable_alias(catalog, &args.name).map(CommandOutcome::from)
+        Some(DisableTarget::Alias(args)) if args.is_filter() => {
+            let names = select_aliases(
+                catalog,
+                args.pattern.as_deref(),
+                args.group.as_ref().map(|group| group.as_deref()),
+            )?;
+            let matched = names.len();
+            let (outcome, changed) = disable_aliases(catalog, &names);
+            let message = if matched == 0 {
+                "No aliases matched the selector.".to_string()
+            } else {
+                format!("Disabled {changed} of {matched} matching aliases.")
+            };
+            Ok(CommandOutcome::with_message(outcome, message))
         }
+        Some(DisableTarget::Alias(args)) => disable_alias(
+            catalog,
+            args.name
+                .as_deref()
+                .expect("clap requires an exact name or a filter"),
+        )
+        .map(CommandOutcome::from),
         Some(DisableTarget::Group(args)) => {
             disable_group(catalog, &args.name, shell).map(CommandOutcome::from)
         }
@@ -58,6 +78,7 @@ pub fn handle_disable(
 mod tests {
     use super::*;
     use crate::catalog::types::Alias;
+    use crate::cli::selector::AliasSelectorArgs;
 
     fn sample_catalog() -> AliasCatalog {
         let mut catalog = AliasCatalog::new();
@@ -111,8 +132,10 @@ mod tests {
         let alias_result = handle_disable(
             &mut catalog,
             DisableCommand {
-                target: Some(DisableTarget::Alias(crate::cli::disable::DisableArgs {
-                    name: "ll".to_string(),
+                target: Some(DisableTarget::Alias(AliasSelectorArgs {
+                    name: Some("ll".to_string()),
+                    pattern: None,
+                    group: None,
                 })),
                 name: None,
             },

--- a/src/app/enable.rs
+++ b/src/app/enable.rs
@@ -1,5 +1,6 @@
 use crate::catalog::types::AliasCatalog;
-use crate::core::enable::{enable_alias, enable_all, enable_group};
+use crate::core::enable::{enable_alias, enable_aliases, enable_all, enable_group};
+use crate::core::selector::select_aliases;
 use crate::core::{Failure, Outcome};
 
 use crate::cli::enable::{EnableCommand, EnableTarget};
@@ -28,9 +29,28 @@ pub fn handle_enable(
     interaction_mode: InteractionMode,
 ) -> Result<CommandOutcome, Failure> {
     match cmd.target {
-        Some(EnableTarget::Alias(args)) => {
-            enable_alias(catalog, &args.name).map(CommandOutcome::from)
+        Some(EnableTarget::Alias(args)) if args.is_filter() => {
+            let names = select_aliases(
+                catalog,
+                args.pattern.as_deref(),
+                args.group.as_ref().map(|group| group.as_deref()),
+            )?;
+            let matched = names.len();
+            let (outcome, changed) = enable_aliases(catalog, &names);
+            let message = if matched == 0 {
+                "No aliases matched the selector.".to_string()
+            } else {
+                format!("Enabled {changed} of {matched} matching aliases.")
+            };
+            Ok(CommandOutcome::with_message(outcome, message))
         }
+        Some(EnableTarget::Alias(args)) => enable_alias(
+            catalog,
+            args.name
+                .as_deref()
+                .expect("clap requires an exact name or a filter"),
+        )
+        .map(CommandOutcome::from),
         Some(EnableTarget::Group(args)) => {
             enable_group(catalog, &args.name, shell).map(CommandOutcome::from)
         }
@@ -58,6 +78,7 @@ pub fn handle_enable(
 mod tests {
     use super::*;
     use crate::catalog::types::Alias;
+    use crate::cli::selector::AliasSelectorArgs;
 
     fn sample_catalog() -> AliasCatalog {
         let mut catalog = AliasCatalog::new();
@@ -111,8 +132,10 @@ mod tests {
         let alias_result = handle_enable(
             &mut catalog,
             EnableCommand {
-                target: Some(EnableTarget::Alias(crate::cli::enable::EnableArgs {
-                    name: "ll".to_string(),
+                target: Some(EnableTarget::Alias(AliasSelectorArgs {
+                    name: Some("ll".to_string()),
+                    pattern: None,
+                    group: None,
                 })),
                 name: None,
             },
@@ -160,5 +183,43 @@ mod tests {
         );
         assert!(catalog.aliases["ll"].enabled);
         assert!(catalog.groups["tools"]);
+    }
+
+    #[test]
+    fn enables_aliases_selected_by_pattern_and_group() {
+        let mut catalog = sample_catalog();
+        catalog.aliases.insert(
+            "lint".to_string(),
+            Alias::new(
+                "cargo clippy".to_string(),
+                Some("tools".to_string()),
+                false,
+                false,
+            ),
+        );
+
+        let result = handle_enable(
+            &mut catalog,
+            EnableCommand {
+                target: Some(EnableTarget::Alias(AliasSelectorArgs {
+                    name: None,
+                    pattern: Some("l*".to_string()),
+                    group: Some(Some("tools".to_string())),
+                })),
+                name: None,
+            },
+            &ShellType::Bash,
+            InteractionMode::Interactive,
+        );
+
+        assert_eq!(
+            result,
+            Ok(CommandOutcome::with_message(
+                Outcome::CatalogChanged,
+                "Enabled 1 of 1 matching aliases."
+            ))
+        );
+        assert!(catalog.aliases["lint"].enabled);
+        assert!(!catalog.aliases["ll"].enabled);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -19,14 +19,14 @@ use crate::core::Outcome;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CommandOutcome {
     pub outcome: Outcome,
-    pub message: Option<&'static str>,
+    pub message: Option<String>,
 }
 
 impl CommandOutcome {
-    pub fn with_message(outcome: Outcome, message: &'static str) -> Self {
+    pub fn with_message(outcome: Outcome, message: impl Into<String>) -> Self {
         Self {
             outcome,
-            message: Some(message),
+            message: Some(message.into()),
         }
     }
 }

--- a/src/app/remove.rs
+++ b/src/app/remove.rs
@@ -3,17 +3,20 @@ use crate::catalog::types::AliasCatalog;
 use crate::core::list::get_aliases_from_single_group;
 use crate::core::r#move::move_alias;
 use crate::core::remove::{remove_alias, remove_aliases, remove_all, remove_group};
+use crate::core::selector::select_aliases;
 use crate::core::{Failure, Outcome};
 
 use super::shell::ShellType;
 
 use crate::cli::interaction::{
-    InteractionMode, prompt_alias_or_group, prompt_confirm_remove_all,
-    prompt_enable_reassigned_aliases, prompt_reassign_group_aliases,
+    InteractionMode, prompt_alias_or_group, prompt_confirm_remove_aliases,
+    prompt_confirm_remove_all, prompt_enable_reassigned_aliases, prompt_reassign_group_aliases,
 };
 
 use crate::cli::remove::{RemoveCommand, RemoveTarget};
+use crate::cli::selector::AliasSelectorArgs;
 
+use super::CommandOutcome;
 use super::resource::{ResourceType, resolve_resource_type};
 
 #[derive(Clone, Copy)]
@@ -21,6 +24,38 @@ enum ReassignedAliasAction {
     Prompt,
     Enable,
     Disable,
+}
+
+fn handle_remove_filter(
+    catalog: &mut AliasCatalog,
+    args: AliasSelectorArgs,
+    confirmation: impl FnOnce(usize) -> bool,
+) -> Result<CommandOutcome, Failure> {
+    let names = select_aliases(
+        catalog,
+        args.pattern.as_deref(),
+        args.group.as_ref().map(|group| group.as_deref()),
+    )?;
+    let matched = names.len();
+    if matched == 0 {
+        return Ok(CommandOutcome::with_message(
+            Outcome::NoChanges,
+            "No aliases matched the selector.",
+        ));
+    }
+
+    if confirmation(matched) {
+        remove_aliases(catalog, &names)?;
+        Ok(CommandOutcome::with_message(
+            Outcome::CatalogChanged,
+            format!("Removed {matched} of {matched} matching aliases."),
+        ))
+    } else {
+        Ok(CommandOutcome::with_message(
+            Outcome::NoChanges,
+            format!("Removed 0 of {matched} matching aliases."),
+        ))
+    }
 }
 
 pub fn handle_remove_all(
@@ -114,9 +149,20 @@ pub fn handle_remove(
     cmd: RemoveCommand,
     shell: &ShellType,
     interaction_mode: InteractionMode,
-) -> Result<Outcome, Failure> {
+) -> Result<CommandOutcome, Failure> {
     match cmd.target {
-        Some(RemoveTarget::Alias(args)) => remove_alias(catalog, &args.name),
+        Some(RemoveTarget::Alias(args)) if args.is_filter() => {
+            handle_remove_filter(catalog, args, |count| {
+                prompt_confirm_remove_aliases(interaction_mode, count)
+            })
+        }
+        Some(RemoveTarget::Alias(args)) => remove_alias(
+            catalog,
+            args.name
+                .as_deref()
+                .expect("clap requires an exact name or a filter"),
+        )
+        .map(CommandOutcome::from),
         Some(RemoveTarget::Group(args)) => {
             let reassigned_alias_action = if args.enable_reassigned {
                 ReassignedAliasAction::Enable
@@ -133,10 +179,12 @@ pub fn handle_remove(
                 reassigned_alias_action,
                 |name, count| prompt_enable_reassigned_aliases(interaction_mode, name, count),
             )
+            .map(CommandOutcome::from)
         }
         Some(RemoveTarget::All) => handle_remove_all(catalog, shell, || {
             prompt_confirm_remove_all(interaction_mode)
-        }),
+        })
+        .map(CommandOutcome::from),
         None => handle_remove_shorthand(
             catalog,
             cmd.name
@@ -146,7 +194,8 @@ pub fn handle_remove(
             |name| prompt_alias_or_group(interaction_mode, name, "removed"),
             |name| prompt_reassign_group_aliases(interaction_mode, name),
             |name, count| prompt_enable_reassigned_aliases(interaction_mode, name, count),
-        ),
+        )
+        .map(CommandOutcome::from),
     }
 }
 
@@ -177,8 +226,10 @@ mod tests {
         let result = handle_remove(
             &mut catalog,
             RemoveCommand {
-                target: Some(RemoveTarget::Alias(crate::cli::remove::RemoveAliasArgs {
-                    name: "ls".to_string(),
+                target: Some(RemoveTarget::Alias(AliasSelectorArgs {
+                    name: Some("ls".to_string()),
+                    pattern: None,
+                    group: None,
                 })),
                 name: None,
             },
@@ -197,8 +248,10 @@ mod tests {
         let result = handle_remove(
             &mut catalog,
             RemoveCommand {
-                target: Some(RemoveTarget::Alias(crate::cli::remove::RemoveAliasArgs {
-                    name: "nonexistent".to_string(),
+                target: Some(RemoveTarget::Alias(AliasSelectorArgs {
+                    name: Some("nonexistent".to_string()),
+                    pattern: None,
+                    group: None,
                 })),
                 name: None,
             },
@@ -206,6 +259,32 @@ mod tests {
             InteractionMode::Interactive,
         );
         assert_matches!(result.err(), Some(Failure::AliasDoesNotExist));
+    }
+
+    #[test]
+    fn declining_filtered_removal_preserves_matches() {
+        let mut catalog = sample_catalog();
+        let result = handle_remove_filter(
+            &mut catalog,
+            AliasSelectorArgs {
+                name: None,
+                pattern: Some("*".to_string()),
+                group: Some(Some("files".to_string())),
+            },
+            |count| {
+                assert_eq!(count, 1);
+                false
+            },
+        );
+
+        assert_eq!(
+            result,
+            Ok(CommandOutcome::with_message(
+                Outcome::NoChanges,
+                "Removed 0 of 1 matching aliases."
+            ))
+        );
+        assert!(catalog.aliases.contains_key("ls"));
     }
 
     #[test]
@@ -225,7 +304,10 @@ mod tests {
             &ShellType::Bash,
             InteractionMode::Interactive,
         );
-        assert_eq!(result.unwrap(), Outcome::CatalogChanged);
+        assert_eq!(
+            result.unwrap(),
+            CommandOutcome::from(Outcome::CatalogChanged)
+        );
         assert!(!catalog.groups.contains_key("files"));
     }
 

--- a/src/cli/disable.rs
+++ b/src/cli/disable.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::selector::AliasSelectorArgs;
+
 #[derive(Args)]
 #[command(
     args_conflicts_with_subcommands = true,
@@ -21,7 +23,7 @@ pub struct DisableCommand {
 pub enum DisableTarget {
     /// Disable an alias
     #[command(visible_alias = "a")]
-    Alias(DisableArgs),
+    Alias(AliasSelectorArgs),
 
     /// Disable a group
     #[command(visible_alias = "g")]

--- a/src/cli/enable.rs
+++ b/src/cli/enable.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::selector::AliasSelectorArgs;
+
 #[derive(Args)]
 #[command(
     args_conflicts_with_subcommands = true,
@@ -21,7 +23,7 @@ pub struct EnableCommand {
 pub enum EnableTarget {
     /// Enable an alias
     #[command(visible_alias = "a")]
-    Alias(EnableArgs),
+    Alias(AliasSelectorArgs),
 
     /// Enable a group
     #[command(visible_alias = "g")]

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -80,6 +80,26 @@ pub fn prompt_confirm_remove_all(mode: InteractionMode) -> bool {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
+pub fn prompt_confirm_remove_aliases(mode: InteractionMode, alias_count: usize) -> bool {
+    if let Some(answer) = non_interactive_answer(
+        mode,
+        &format!("remove {alias_count} aliases matching the selector"),
+    ) {
+        return answer;
+    }
+    remove_aliases_confirm(alias_count).interact().unwrap()
+}
+
+fn remove_aliases_confirm(alias_count: usize) -> Confirm<'static> {
+    Confirm::new()
+        .with_prompt(format!(
+            "Remove {alias_count} alias{} matching the selector?",
+            if alias_count == 1 { "" } else { "es" }
+        ))
+        .default(false)
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_alias_or_group(mode: InteractionMode, name: &str, action: &str) -> bool {
     if let Some(answer) = non_interactive_answer(
         mode,
@@ -163,6 +183,11 @@ mod tests {
     #[test]
     fn builds_alias_or_group_select() {
         drop(alias_or_group_select("tools", "enabled"));
+    }
+
+    #[test]
+    fn builds_remove_aliases_confirm() {
+        drop(remove_aliases_confirm(2));
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod list;
 pub(crate) mod r#move;
 pub(crate) mod remove;
 pub(crate) mod rename;
+pub(crate) mod selector;
 pub(crate) mod sort;
 pub(crate) mod sync;
 
@@ -223,7 +224,7 @@ mod tests {
             Commands::Remove(RemoveCommand {
                 target: Some(RemoveTarget::Alias(args)),
                 ..
-            }) if args.name == "all"
+            }) if args.name.as_deref() == Some("all")
         ));
     }
 
@@ -352,8 +353,47 @@ mod tests {
             Commands::Enable(EnableCommand {
                 target: Some(EnableTarget::Alias(args)),
                 ..
-            }) if args.name == "all"
+            }) if args.name.as_deref() == Some("all")
         ));
+    }
+
+    #[test]
+    fn parses_alias_selector_flags_and_rejects_ambiguous_selectors() {
+        let filtered = Cli::try_parse_from([
+            "aliasmgr",
+            "disable",
+            "alias",
+            "--pattern",
+            "b*",
+            "--group",
+            "dev",
+        ])
+        .expect("pattern and group selectors should combine");
+        assert!(matches!(
+            filtered.command,
+            Commands::Disable(DisableCommand {
+                target: Some(DisableTarget::Alias(args)),
+                ..
+            }) if args.name.is_none()
+                && args.pattern.as_deref() == Some("b*")
+                && args.group == Some(Some("dev".to_string()))
+        ));
+
+        let ungrouped = Cli::try_parse_from(["aliasmgr", "remove", "alias", "--group"])
+            .expect("an empty group selector should select ungrouped aliases");
+        assert!(matches!(
+            ungrouped.command,
+            Commands::Remove(RemoveCommand {
+                target: Some(RemoveTarget::Alias(args)),
+                ..
+            }) if args.group == Some(None)
+        ));
+
+        assert!(Cli::try_parse_from(["aliasmgr", "enable", "alias"]).is_err());
+        assert!(
+            Cli::try_parse_from(["aliasmgr", "enable", "alias", "ll", "--pattern", "l*",]).is_err()
+        );
+        assert!(Cli::try_parse_from(["aliasmgr", "enable", "alias", "--pattern", "["]).is_err());
     }
 
     #[test]
@@ -375,7 +415,7 @@ mod tests {
             Commands::Disable(DisableCommand {
                 target: Some(DisableTarget::Alias(args)),
                 ..
-            }) if args.name == "group"
+            }) if args.name.as_deref() == Some("group")
         ));
 
         let all =
@@ -395,7 +435,7 @@ mod tests {
             Commands::Disable(DisableCommand {
                 target: Some(DisableTarget::Alias(args)),
                 ..
-            }) if args.name == "all"
+            }) if args.name.as_deref() == Some("all")
         ));
     }
 

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::selector::AliasSelectorArgs;
+
 #[derive(Args)]
 #[command(
     args_conflicts_with_subcommands = true,
@@ -21,7 +23,7 @@ pub struct RemoveCommand {
 pub enum RemoveTarget {
     /// Remove an alias
     #[command(visible_alias = "a")]
-    Alias(RemoveAliasArgs),
+    Alias(AliasSelectorArgs),
 
     /// Remove a group and all its aliases
     #[command(visible_alias = "g")]
@@ -29,13 +31,6 @@ pub enum RemoveTarget {
 
     /// Remove all aliases and groups
     All,
-}
-
-#[derive(Args)]
-pub struct RemoveAliasArgs {
-    /// Name of the alias to remove
-    #[arg()]
-    pub name: String,
 }
 
 #[derive(Args)]

--- a/src/cli/selector.rs
+++ b/src/cli/selector.rs
@@ -1,0 +1,36 @@
+use clap::{ArgGroup, Args};
+
+#[derive(Args)]
+#[command(
+    group(
+        ArgGroup::new("alias_selector")
+            .args(["name", "pattern", "group"])
+            .required(true)
+            .multiple(true)
+    )
+)]
+pub struct AliasSelectorArgs {
+    /// Exact alias name
+    #[arg(conflicts_with_all = ["pattern", "group"])]
+    pub name: Option<String>,
+
+    /// Select aliases whose names match GLOB
+    #[arg(long, value_name = "GLOB", value_parser = validate_glob)]
+    pub pattern: Option<String>,
+
+    /// Select aliases in GROUP. If left empty, select ungrouped aliases.
+    #[arg(short, long, num_args = 0..=1, value_name = "GROUP")]
+    pub group: Option<Option<String>>,
+}
+
+impl AliasSelectorArgs {
+    pub fn is_filter(&self) -> bool {
+        self.pattern.is_some() || self.group.is_some()
+    }
+}
+
+fn validate_glob(pattern: &str) -> Result<String, String> {
+    globset::Glob::new(pattern)
+        .map(|_| pattern.to_string())
+        .map_err(|error| format!("invalid glob pattern: {error}"))
+}

--- a/src/core/disable.rs
+++ b/src/core/disable.rs
@@ -60,6 +60,27 @@ pub fn disable_all(catalog: &mut AliasCatalog) -> Result<Outcome, Failure> {
     Ok(Outcome::CatalogChanged)
 }
 
+pub fn disable_aliases(catalog: &mut AliasCatalog, names: &[String]) -> (Outcome, usize) {
+    let mut changed = 0;
+    for name in names {
+        let alias = catalog
+            .aliases
+            .get_mut(name)
+            .expect("selected aliases exist in the catalog");
+        if alias.enabled {
+            alias.enabled = false;
+            changed += 1;
+        }
+    }
+
+    let outcome = if changed == 0 {
+        Outcome::NoChanges
+    } else {
+        Outcome::CatalogChanged
+    };
+    (outcome, changed)
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {

--- a/src/core/enable.rs
+++ b/src/core/enable.rs
@@ -60,6 +60,27 @@ pub fn enable_all(catalog: &mut AliasCatalog) -> Result<Outcome, Failure> {
     Ok(Outcome::CatalogChanged)
 }
 
+pub fn enable_aliases(catalog: &mut AliasCatalog, names: &[String]) -> (Outcome, usize) {
+    let mut changed = 0;
+    for name in names {
+        let alias = catalog
+            .aliases
+            .get_mut(name)
+            .expect("selected aliases exist in the catalog");
+        if !alias.enabled {
+            alias.enabled = true;
+            changed += 1;
+        }
+    }
+
+    let outcome = if changed == 0 {
+        Outcome::NoChanges
+    } else {
+        Outcome::CatalogChanged
+    };
+    (outcome, changed)
+}
+
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod list;
 pub(crate) mod r#move;
 pub(crate) mod remove;
 pub(crate) mod rename;
+pub(crate) mod selector;
 pub(crate) mod sort;
 pub(crate) mod sync;
 pub(crate) mod validation;
@@ -21,6 +22,7 @@ pub enum Failure {
     AliasAlreadyExists,
     GroupAlreadyExists,
     InvalidCatalog,
+    InvalidPattern,
 }
 
 /// Represents the outcome of core operations.

--- a/src/core/selector.rs
+++ b/src/core/selector.rs
@@ -1,0 +1,96 @@
+use globset::Glob;
+use log::error;
+
+use crate::catalog::types::AliasCatalog;
+
+use super::Failure;
+
+pub fn select_aliases(
+    catalog: &AliasCatalog,
+    pattern: Option<&str>,
+    group: Option<Option<&str>>,
+) -> Result<Vec<String>, Failure> {
+    if let Some(Some(group)) = group
+        && !catalog.groups.contains_key(group)
+    {
+        error!("Group '{}' does not exist", group);
+        return Err(Failure::GroupDoesNotExist);
+    }
+
+    let matcher = pattern
+        .map(|pattern| {
+            Glob::new(pattern)
+                .map(|glob| glob.compile_matcher())
+                .map_err(|error| {
+                    error!("Invalid glob pattern '{}': {}", pattern, error);
+                    Failure::InvalidPattern
+                })
+        })
+        .transpose()?;
+
+    Ok(catalog
+        .aliases
+        .iter()
+        .filter(|(name, _)| {
+            matcher
+                .as_ref()
+                .is_none_or(|matcher| matcher.is_match(name))
+        })
+        .filter(|(_, alias)| group.is_none_or(|group| alias.group.as_deref() == group))
+        .map(|(name, _)| name.clone())
+        .collect())
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::catalog::types::Alias;
+
+    fn sample_catalog() -> AliasCatalog {
+        let mut catalog = AliasCatalog::new();
+        catalog.groups.insert("dev".into(), true);
+        catalog.groups.insert("ops".into(), true);
+        catalog.aliases.insert(
+            "build".into(),
+            Alias::new("cargo build".into(), Some("dev".into()), true, false),
+        );
+        catalog.aliases.insert(
+            "bench".into(),
+            Alias::new("cargo bench".into(), Some("dev".into()), true, false),
+        );
+        catalog.aliases.insert(
+            "deploy".into(),
+            Alias::new("deploy".into(), Some("ops".into()), true, false),
+        );
+        catalog.aliases.insert(
+            "local".into(),
+            Alias::new("echo local".into(), None, true, false),
+        );
+        catalog
+    }
+
+    #[test]
+    fn combines_pattern_and_group_filters() {
+        let selected = select_aliases(&sample_catalog(), Some("b*"), Some(Some("dev"))).unwrap();
+        assert_eq!(selected, ["build", "bench"]);
+    }
+
+    #[test]
+    fn selects_ungrouped_aliases() {
+        let selected = select_aliases(&sample_catalog(), None, Some(None)).unwrap();
+        assert_eq!(selected, ["local"]);
+    }
+
+    #[test]
+    fn rejects_missing_groups_and_invalid_patterns() {
+        assert_eq!(
+            select_aliases(&sample_catalog(), None, Some(Some("missing"))),
+            Err(Failure::GroupDoesNotExist)
+        );
+        assert_eq!(
+            select_aliases(&sample_catalog(), Some("["), None),
+            Err(Failure::InvalidPattern)
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,7 @@ fn main() {
         Commands::Add(cmd) => {
             handle_add(&mut catalog, cmd, &shell, interaction_mode).map(CommandOutcome::from)
         }
-        Commands::Remove(cmd) => {
-            handle_remove(&mut catalog, cmd, &shell, interaction_mode).map(CommandOutcome::from)
-        }
+        Commands::Remove(cmd) => handle_remove(&mut catalog, cmd, &shell, interaction_mode),
         Commands::Move(cmd) => {
             handle_move(&mut catalog, cmd, interaction_mode).map(CommandOutcome::from)
         }

--- a/tests/bulk_filters.rs
+++ b/tests/bulk_filters.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_aliasmgr(catalog: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(args)
+        .env("ALIASMGR_CATALOG_PATH", catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .output()
+        .expect("aliasmgr command should run")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn enable_and_disable_filter_by_pattern_group_and_ungrouped() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(
+        &catalog,
+        concat!(
+            "local = \"echo local\"\n",
+            "zglob = { command = \"*.rs\", global = true }\n",
+            "[dev]\n",
+            "build = \"cargo build\"\n",
+            "bench = { command = \"cargo bench\", enabled = false }\n",
+            "[ops]\n",
+            "deploy = \"deploy\"\n",
+        ),
+    )
+    .unwrap();
+
+    let disable = run_aliasmgr(
+        &catalog,
+        &["disable", "alias", "--pattern", "b*", "--group", "dev"],
+    );
+    assert!(disable.status.success(), "command failed: {disable:?}");
+    assert_eq!(stdout(&disable), "Disabled 1 of 2 matching aliases.");
+
+    let enable = run_aliasmgr(&catalog, &["enable", "alias", "--group", "dev"]);
+    assert!(enable.status.success(), "command failed: {enable:?}");
+    assert_eq!(stdout(&enable), "Enabled 2 of 2 matching aliases.");
+
+    let disable_ungrouped = run_aliasmgr(&catalog, &["disable", "alias", "--group"]);
+    assert!(
+        disable_ungrouped.status.success(),
+        "command failed: {disable_ungrouped:?}"
+    );
+    assert_eq!(
+        stdout(&disable_ungrouped),
+        "Disabled 2 of 2 matching aliases."
+    );
+
+    let content = fs::read_to_string(&catalog).unwrap();
+    assert!(content.contains("local = { command = \"echo local\", enabled = false"));
+    assert!(content.contains("zglob = { command = \"*.rs\", enabled = false"));
+    assert!(content.contains("build = { command = \"cargo build\", enabled = true"));
+    assert!(content.contains("bench = { command = \"cargo bench\", enabled = true"));
+    assert!(content.contains("deploy = \"deploy\""));
+    assert!(content.contains("[dev]"));
+    assert!(content.contains("[ops]"));
+}
+
+#[test]
+fn remove_by_group_prompts_once_and_preserves_the_group() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original =
+        "[dev]\nbuild = \"cargo build\"\nbench = \"cargo bench\"\n[ops]\ndeploy = \"deploy\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    let no_input = run_aliasmgr(
+        &catalog,
+        &["remove", "alias", "--group", "dev", "--no-input"],
+    );
+    assert_eq!(no_input.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&no_input.stderr)
+            .contains("remove 2 aliases matching the selector")
+    );
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+
+    let force = run_aliasmgr(&catalog, &["remove", "alias", "--group", "dev", "--force"]);
+    assert!(force.status.success(), "command failed: {force:?}");
+    assert_eq!(stdout(&force), "Removed 2 of 2 matching aliases.");
+    assert_eq!(
+        fs::read_to_string(&catalog).unwrap(),
+        "[dev]\n\n[ops]\ndeploy = \"deploy\"\n"
+    );
+}
+
+#[test]
+fn empty_match_is_a_no_op_and_invalid_selectors_do_not_modify_the_catalog() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original = "ll = \"ls -la\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    for command in ["enable", "disable"] {
+        let empty = run_aliasmgr(&catalog, &[command, "alias", "--pattern", "missing-*"]);
+        assert!(empty.status.success(), "command failed: {empty:?}");
+        assert_eq!(stdout(&empty), "No aliases matched the selector.");
+    }
+
+    let empty = run_aliasmgr(
+        &catalog,
+        &["remove", "alias", "--pattern", "missing-*", "--no-input"],
+    );
+    assert!(empty.status.success(), "command failed: {empty:?}");
+    assert_eq!(stdout(&empty), "No aliases matched the selector.");
+
+    let invalid = run_aliasmgr(&catalog, &["disable", "alias", "--pattern", "["]);
+    assert_eq!(invalid.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&invalid.stderr).contains("invalid glob pattern"));
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+}

--- a/tests/bulk_filters.rs
+++ b/tests/bulk_filters.rs
@@ -115,5 +115,13 @@ fn empty_match_is_a_no_op_and_invalid_selectors_do_not_modify_the_catalog() {
     let invalid = run_aliasmgr(&catalog, &["disable", "alias", "--pattern", "["]);
     assert_eq!(invalid.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&invalid.stderr).contains("invalid glob pattern"));
+
+    for command in ["enable", "disable", "remove"] {
+        let missing_group = run_aliasmgr(&catalog, &[command, "alias", "--group", "missing"]);
+        assert!(
+            String::from_utf8_lossy(&missing_group.stderr)
+                .contains("Group 'missing' does not exist")
+        );
+    }
     assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
 }

--- a/tests/shell_integration.rs
+++ b/tests/shell_integration.rs
@@ -157,6 +157,44 @@ disable_output="$(aliasmgr disable all)"
 }
 
 #[test]
+fn filtered_bulk_operations_reconcile_managed_aliases_once() {
+    let catalog = tempfile::NamedTempFile::new().unwrap();
+    let script = r#"
+eval "$("$1" init bash --catalog "$2")"
+aliasmgr add group dev
+aliasmgr add alias build 'cargo build' --group dev
+aliasmgr add alias bench 'cargo bench' --group dev --disabled
+aliasmgr add alias deploy 'deploy' --group dev
+__aliasmgr_prompt_sync
+alias build >/dev/null || exit 52
+! alias bench 2>/dev/null || exit 53
+
+disable_output="$(aliasmgr disable alias --pattern 'b*' --group dev)"
+[ "$disable_output" = 'Disabled 1 of 2 matching aliases.' ] || exit 54
+__aliasmgr_prompt_sync
+! alias build 2>/dev/null || exit 55
+! alias bench 2>/dev/null || exit 56
+alias deploy >/dev/null || exit 57
+
+enable_output="$(aliasmgr enable alias --group dev)"
+[ "$enable_output" = 'Enabled 2 of 3 matching aliases.' ] || exit 58
+__aliasmgr_prompt_sync
+alias build >/dev/null || exit 59
+alias bench >/dev/null || exit 60
+
+remove_output="$(aliasmgr remove alias --pattern 'b*' --group dev --force)"
+[ "$remove_output" = 'Removed 2 of 2 matching aliases.' ] || exit 61
+__aliasmgr_prompt_sync
+! alias build 2>/dev/null || exit 62
+! alias bench 2>/dev/null || exit 63
+alias deploy >/dev/null || exit 64
+command grep -q '^\[dev\]$' "$2" || exit 65
+"#;
+
+    assert_success(run_shell("bash", script, catalog.path()).unwrap());
+}
+
+#[test]
 fn removing_enabled_group_with_reassign_preserves_enabled_alias() {
     let catalog = tempfile::NamedTempFile::new().unwrap();
     let script = r#"


### PR DESCRIPTION
## Summary

- add reusable `--pattern <glob>` and `--group [group]` selectors to explicit alias enable, disable, and remove commands
- combine pattern and group selectors by intersection while preserving exact-name behavior and group records
- confirm filtered removals once and report matched/changed counts for every filtered operation
- document selector behavior and cover catalog mutation, prompt controls, invalid/empty selectors, and live shell reconciliation

## Validation

- `cargo fmt --check`
- `cargo build --verbose`
- `cargo test --verbose` (276 tests passed)
- `cargo clippy`
- `cargo +nightly llvm-cov --all-features --workspace --lcov --output-path /tmp/aliasmgr-issue6-lcov.info`

## Acceptance criteria

- bulk enable/disable by pattern: covered by CLI and shell-integration tests
- bulk enable/disable/remove by group: covered, including bare `--group` for ungrouped aliases
- pattern and group filters combine by intersection
- empty matches are successful no-ops with a clear message
- mixed enabled/disabled batches report matched and changed counts
- filtered removal prompts once, defaults to no, honors `--force`, and fails safely with `--no-input`
- catalog persistence and prompt synchronization reconcile the live shell once per command outcome

Closes #6
