### PR TITLE
Clarify prompt controls and help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ status = "auto"
 
 ## Commands
 
-- `aliasmgr add <name> <command> [-d|--description <text>] [-t|--tag <tag>]... [--disabled] [-g|--global]`
-- `aliasmgr edit <name> [command] [-d|--description <text> | --clear-description] [-a|--add-tag <tag>]... [-r|--remove-tag <tag>]... [-g|--global | --no-global]`
+- `aliasmgr add <name> <command> [-g|--global] [-t|--tag <tag>]... [-d|--description <text>] [--disabled]`
+- `aliasmgr edit <name> [command] [-a|--add-tag <tag>]... [-r|--remove-tag <tag>]... [-d|--description <text> | --clear-description] [-g|--global | --no-global]`
 - `aliasmgr list [pattern] [-t|--tag <tag>]... [-d|--disabled | --all] [-g|--global] [--columns <columns>] [-f|--format <human|json>]`
 - `aliasmgr remove <name>`
 - `aliasmgr remove alias <name>`

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ status = "auto"
 
 ## Commands
 
-- `aliasmgr add <name> <command> [--description <text>] [--tag <tag>]... [--disabled] [--global]`
-- `aliasmgr edit <name> [command] [--description <text> | --clear-description] [--add-tag <tag>]... [--remove-tag <tag>]... [--global | --no-global]`
-- `aliasmgr list [pattern] [--tag <tag>]... [--disabled | --all] [--global] [--columns <columns>] [--format <human|json>]`
+- `aliasmgr add <name> <command> [-d|--description <text>] [-t|--tag <tag>]... [--disabled] [-g|--global]`
+- `aliasmgr edit <name> [command] [-d|--description <text> | --clear-description] [-a|--add-tag <tag>]... [-r|--remove-tag <tag>]... [-g|--global | --no-global]`
+- `aliasmgr list [pattern] [-t|--tag <tag>]... [-d|--disabled | --all] [-g|--global] [--columns <columns>] [-f|--format <human|json>]`
 - `aliasmgr remove <name>`
 - `aliasmgr remove alias <name>`
-- `aliasmgr remove alias [--pattern <glob>] [--tag <tag>]...` (bulk filter; prompts once)
+- `aliasmgr remove alias [-p|--pattern <glob>] [-t|--tag <tag>]...` (bulk filter; prompts once)
 - `aliasmgr remove tag <tag>` (detaches the tag without removing aliases)
 - `aliasmgr remove tag <tag> --aliases` (removes every tagged alias after one prompt)
 - `aliasmgr remove all`
@@ -89,12 +89,12 @@ status = "auto"
 - `aliasmgr rename tag <old-tag> <new-tag>`
 - `aliasmgr enable <name>`
 - `aliasmgr enable alias <name>`
-- `aliasmgr enable alias [--pattern <glob>] [--tag <tag>]...`
+- `aliasmgr enable alias [-p|--pattern <glob>] [-t|--tag <tag>]...`
 - `aliasmgr enable tag <tag>`
 - `aliasmgr enable all`
 - `aliasmgr disable <name>`
 - `aliasmgr disable alias <name>`
-- `aliasmgr disable alias [--pattern <glob>] [--tag <tag>]...`
+- `aliasmgr disable alias [-p|--pattern <glob>] [-t|--tag <tag>]...`
 - `aliasmgr disable tag <tag>`
 - `aliasmgr disable all`
 - `aliasmgr sync`
@@ -107,7 +107,8 @@ Notes:
 - Repeat `--tag` when creating an alias or filtering by multiple tags. Filters use AND semantics: every supplied tag must be present.
 - `list` shows enabled aliases by default. Use `--disabled` for disabled aliases or `--all` for both.
 - Tags are case-sensitive and cannot be empty or contain whitespace.
-- `--force` and `--no-input` are mutually exclusive global automation flags. `--force` accepts overwrite and removal prompts; `--no-input` exits with status 2 if input would be required.
+- `-y`/`--yes`, `-n`/`--no`, and `-N`/`--no-input` are mutually exclusive global prompt controls. They respectively accept, decline, or fail with status 2 when confirmation is required.
+- Global options also provide `-c`/`--color`, `-D`/`--debug`, `-q`/`--quiet`, and `-v`/`--verbose`.
 - Alias names cannot be empty or contain whitespace or `=`.
 - Global aliases only work on Zsh and are skipped for other shells.
 - Adding or editing an alias warns without blocking when its name conflicts with a builtin in the active Bash/Zsh shell or an executable found on `PATH`.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ status = "auto"
 
 - `aliasmgr add <name> <command> [-g|--global] [-t|--tag <tag>]... [-d|--description <text>] [--disabled]`
 - `aliasmgr edit <name> [command] [-a|--add-tag <tag>]... [-r|--remove-tag <tag>]... [-d|--description <text> | --clear-description] [-g|--global | --no-global]`
-- `aliasmgr import <path>... [--tag <tag>]... [--dry-run] [--skip-existing | --replace-existing]`
+- `aliasmgr import <path>... [-d|--dry-run] [-s|--skip-existing | -r|--replace-existing] [-t|--tag <tag>]...`
 - `aliasmgr list [pattern] [-t|--tag <tag>]... [-d|--disabled | --all] [-g|--global] [--columns <columns>] [-f|--format <human|json>]`
 - `aliasmgr remove <name>`
 - `aliasmgr remove alias <name>`
@@ -106,7 +106,7 @@ For more details, use `-h` or `--help`.
 Notes:
 
 - Repeat `--tag` when creating an alias or filtering by multiple tags. Filters use AND semantics: every supplied tag must be present.
-- `import` reads ordinary Bash and Zsh alias declarations from one or more files. Unsupported lines are skipped. Existing aliases prompt before replacement and default to being kept; use `--skip-existing` to keep them non-interactively, or `--replace-existing`/`--yes` to replace them. `--dry-run` reports counts without prompting or changing the catalog.
+- `import` reads ordinary Bash and Zsh alias declarations from one or more files. Unsupported lines are skipped. Existing aliases prompt before replacement and default to being kept. `--yes` behaves like `--replace-existing`, while `--no` behaves like `--skip-existing`; the command-specific policies also work with `--no-input`. `--dry-run` reports counts without prompting or changing the catalog.
 - `list` shows enabled aliases by default. Use `--disabled` for disabled aliases or `--all` for both.
 - Tags are case-sensitive and cannot be empty or contain whitespace.
 - `-y`/`--yes`, `-n`/`--no`, and `-N`/`--no-input` are mutually exclusive global prompt controls. They respectively accept, decline, or fail with status 2 when confirmation is required.

--- a/src/app/file_path.rs
+++ b/src/app/file_path.rs
@@ -2,9 +2,13 @@ use crate::cli::interaction::{InteractionMode, prompt_use_non_existing_catalog_f
 use std::env;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
-
 pub const CATALOG_FILE_ENV_VAR: &str = "ALIASMGR_CATALOG_PATH";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CatalogPathDecision {
+    Use(Option<PathBuf>),
+    Decline,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FileType {
@@ -17,15 +21,9 @@ impl FileType {
             FileType::Catalog => CATALOG_FILE_ENV_VAR,
         }
     }
-
-    fn display_name(self) -> &'static str {
-        match self {
-            FileType::Catalog => "Catalog file",
-        }
-    }
 }
 
-pub fn determine_catalog_path(mode: InteractionMode) -> Result<Option<PathBuf>> {
+pub fn determine_catalog_path(mode: InteractionMode) -> CatalogPathDecision {
     determine_configured_file_path(FileType::Catalog, |path| {
         prompt_use_non_existing_catalog_file(mode, path)
     })
@@ -34,33 +32,25 @@ pub fn determine_catalog_path(mode: InteractionMode) -> Result<Option<PathBuf>> 
 fn determine_configured_file_path(
     file_type: FileType,
     prompt: impl Fn(&str) -> bool,
-) -> Result<Option<PathBuf>> {
+) -> CatalogPathDecision {
     if let Ok(path) = env::var(file_type.env_var()) {
         let path = PathBuf::from(path);
-        handle_configured_file_path(&path, prompt, file_type)
+        handle_configured_file_path(&path, prompt)
     } else {
-        Ok(None)
+        CatalogPathDecision::Use(None)
     }
 }
 
-fn handle_configured_file_path(
-    path: &Path,
-    create: impl Fn(&str) -> bool,
-    file_type: FileType,
-) -> Result<Option<PathBuf>> {
+fn handle_configured_file_path(path: &Path, create: impl Fn(&str) -> bool) -> CatalogPathDecision {
     if path.exists() {
-        return Ok(Some(path.to_path_buf()));
+        return CatalogPathDecision::Use(Some(path.to_path_buf()));
     }
 
     if create(path.to_str().unwrap()) {
-        return Ok(Some(path.to_path_buf()));
+        return CatalogPathDecision::Use(Some(path.to_path_buf()));
     }
 
-    bail!(
-        "{} '{}' does not exist and user chose not to use it.",
-        file_type.display_name(),
-        path.to_str().unwrap()
-    );
+    CatalogPathDecision::Decline
 }
 
 #[cfg(test)]
@@ -76,47 +66,37 @@ mod tests {
             CATALOG_FILE_ENV_VAR,
             Some(temp_file.path().to_str().unwrap()),
             || {
-                let result = determine_catalog_path(InteractionMode::Interactive).unwrap();
-                assert_eq!(result, Some(temp_file.path().to_path_buf()));
+                let result = determine_catalog_path(InteractionMode::Interactive);
+                assert_eq!(
+                    result,
+                    CatalogPathDecision::Use(Some(temp_file.path().to_path_buf()))
+                );
             },
         );
     }
 
     #[test]
     fn test_determine_catalog_path_set_non_existing_file_user_accepts() {
-        let result = handle_configured_file_path(
-            &PathBuf::from("/non/existing/catalog/file"),
-            |_| true,
-            FileType::Catalog,
-        );
-        assert!(result.is_ok());
+        let result =
+            handle_configured_file_path(&PathBuf::from("/non/existing/catalog/file"), |_| true);
         assert_eq!(
-            result.unwrap(),
-            Some(PathBuf::from("/non/existing/catalog/file"))
+            result,
+            CatalogPathDecision::Use(Some(PathBuf::from("/non/existing/catalog/file")))
         );
     }
 
     #[test]
     fn test_determine_catalog_path_set_non_existing_file_user_declines() {
-        let result = handle_configured_file_path(
-            &PathBuf::from("/non/existing/catalog/file"),
-            |_| false,
-            FileType::Catalog,
-        );
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Catalog file '/non/existing/catalog/file'")
-        );
+        let result =
+            handle_configured_file_path(&PathBuf::from("/non/existing/catalog/file"), |_| false);
+        assert_eq!(result, CatalogPathDecision::Decline);
     }
 
     #[test]
     fn test_determine_catalog_path_env_var_not_set() {
         with_var(CATALOG_FILE_ENV_VAR, None as Option<&str>, || {
-            let result = determine_catalog_path(InteractionMode::Interactive).unwrap();
-            assert_eq!(result, None);
+            let result = determine_catalog_path(InteractionMode::Interactive);
+            assert_eq!(result, CatalogPathDecision::Use(None));
         });
     }
 }

--- a/src/app/import.rs
+++ b/src/app/import.rs
@@ -31,11 +31,10 @@ pub fn handle_import(
     catalog: &mut AliasCatalog,
     args: ImportCommand,
     interaction_mode: InteractionMode,
-    force: bool,
 ) -> Result<CommandOutcome, Failure> {
-    let policy = if force || args.replace_existing {
+    let policy = if args.replace_existing || interaction_mode == InteractionMode::Yes {
         CollisionPolicy::Replace
-    } else if args.skip_existing {
+    } else if args.skip_existing || interaction_mode == InteractionMode::No {
         CollisionPolicy::Skip
     } else {
         CollisionPolicy::Prompt

--- a/src/app/sync.rs
+++ b/src/app/sync.rs
@@ -1,6 +1,5 @@
 use super::shell::ShellType;
 use crate::catalog::types::AliasCatalog;
-use crate::cli::interaction::InteractionMode;
 use crate::cli::sync::ShellSyncCommand;
 use crate::core::sync::{
     CATALOG_REVISION_ENV_VAR, MANAGED_ALIASES_ENV_VAR, generate_reconciliation_script,
@@ -17,7 +16,6 @@ pub fn handle_shell_sync(
     catalog: &AliasCatalog,
     shell: &ShellType,
     cmd: ShellSyncCommand,
-    interaction_mode: InteractionMode,
 ) -> String {
     let managed_aliases = std::env::var(MANAGED_ALIASES_ENV_VAR).unwrap_or_default();
     let applied_revision = std::env::var(CATALOG_REVISION_ENV_VAR).unwrap_or_default();
@@ -27,7 +25,7 @@ pub fn handle_shell_sync(
         shell,
         &managed_aliases,
         &applied_revision,
-        cmd.if_changed && interaction_mode != InteractionMode::Force,
+        cmd.if_changed && !cmd.force,
     )
 }
 
@@ -55,8 +53,10 @@ mod tests {
                 let script = handle_shell_sync(
                     &catalog,
                     &ShellType::Bash,
-                    ShellSyncCommand { if_changed: true },
-                    InteractionMode::Interactive,
+                    ShellSyncCommand {
+                        force: false,
+                        if_changed: true,
+                    },
                 );
                 assert!(script.contains("unalias -- 'old'"));
                 assert!(script.contains("alias -- 'current=echo current'"));

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,16 +6,16 @@ use super::validate_tag;
 pub struct AddCommand {
     pub name: String,
     pub command: String,
-    /// Describe what the alias does
-    #[arg(short = 'd', long)]
-    pub description: Option<String>,
+    /// Create a Zsh global alias
+    #[arg(short, long)]
+    pub global: bool,
     /// Add a tag; repeat to add multiple tags
     #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
     pub tag: Vec<String>,
+    /// Describe what the alias does
+    #[arg(short, long)]
+    pub description: Option<String>,
     /// Create the alias in a disabled state
     #[arg(long)]
     pub disabled: bool,
-    /// Create a Zsh global alias
-    #[arg(short = 'g', long)]
-    pub global: bool,
 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,13 +6,16 @@ use super::validate_tag;
 pub struct AddCommand {
     pub name: String,
     pub command: String,
-    #[arg(long)]
+    /// Describe what the alias does
+    #[arg(short = 'd', long)]
     pub description: Option<String>,
     /// Add a tag; repeat to add multiple tags
     #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
     pub tag: Vec<String>,
-    #[arg(short, long)]
-    pub disabled: bool,
+    /// Create the alias in a disabled state
     #[arg(long)]
+    pub disabled: bool,
+    /// Create a Zsh global alias
+    #[arg(short = 'g', long)]
     pub global: bool,
 }

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -11,7 +11,7 @@ pub struct EditCommand {
     pub command: Option<String>,
 
     /// Set the alias description
-    #[arg(long, conflicts_with = "clear_description")]
+    #[arg(short = 'd', long, conflicts_with = "clear_description")]
     pub description: Option<String>,
 
     /// Remove the alias description
@@ -19,11 +19,11 @@ pub struct EditCommand {
     pub clear_description: bool,
 
     /// Add a tag; repeat to add multiple tags
-    #[arg(long, value_name = "TAG", value_parser = validate_tag)]
+    #[arg(short = 'a', long, value_name = "TAG", value_parser = validate_tag)]
     pub add_tag: Vec<String>,
 
     /// Remove a tag; repeat to remove multiple tags
-    #[arg(long, value_name = "TAG", value_parser = validate_tag)]
+    #[arg(short = 'r', long, value_name = "TAG", value_parser = validate_tag)]
     pub remove_tag: Vec<String>,
 
     /// Make the alias global

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -10,21 +10,21 @@ pub struct EditCommand {
     /// Replacement command
     pub command: Option<String>,
 
+    /// Add a tag; repeat to add multiple tags
+    #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
+    pub add_tag: Vec<String>,
+
+    /// Remove a tag; repeat to remove multiple tags
+    #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
+    pub remove_tag: Vec<String>,
+
     /// Set the alias description
-    #[arg(short = 'd', long, conflicts_with = "clear_description")]
+    #[arg(short, long, conflicts_with = "clear_description")]
     pub description: Option<String>,
 
     /// Remove the alias description
     #[arg(long)]
     pub clear_description: bool,
-
-    /// Add a tag; repeat to add multiple tags
-    #[arg(short = 'a', long, value_name = "TAG", value_parser = validate_tag)]
-    pub add_tag: Vec<String>,
-
-    /// Remove a tag; repeat to remove multiple tags
-    #[arg(short = 'r', long, value_name = "TAG", value_parser = validate_tag)]
-    pub remove_tag: Vec<String>,
 
     /// Make the alias global
     #[arg(short, long, conflicts_with = "no_global")]

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -9,16 +9,16 @@ pub struct ImportCommand {
     /// Bash or Zsh files containing alias declarations
     #[arg(required = true)]
     pub paths: Vec<PathBuf>,
+    /// Report what would happen without changing the catalog
+    #[arg(short, long)]
+    pub dry_run: bool,
+    /// Keep catalog entries when imported aliases have the same names
+    #[arg(short, long, conflicts_with = "replace_existing")]
+    pub skip_existing: bool,
+    /// Replace catalog entries when imported aliases have the same names
+    #[arg(short, long, conflicts_with = "skip_existing")]
+    pub replace_existing: bool,
     /// Add a tag to every imported alias; repeat to add multiple tags
     #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
     pub tag: Vec<String>,
-    /// Report what would happen without changing the catalog
-    #[arg(long)]
-    pub dry_run: bool,
-    /// Keep catalog entries when imported aliases have the same names
-    #[arg(long, conflicts_with = "replace_existing")]
-    pub skip_existing: bool,
-    /// Replace catalog entries when imported aliases have the same names
-    #[arg(long, conflicts_with = "skip_existing")]
-    pub replace_existing: bool,
 }

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -5,13 +5,15 @@ const INPUT_REQUIRED_EXIT_CODE: i32 = 2;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InteractionMode {
     Interactive,
-    Force,
+    Yes,
+    No,
     NoInput,
 }
 
 fn non_interactive_answer(mode: InteractionMode, prompt: &str) -> Option<bool> {
     match mode {
-        InteractionMode::Force => Some(true),
+        InteractionMode::Yes => Some(true),
+        InteractionMode::No => Some(false),
         InteractionMode::NoInput => {
             eprintln!("ERROR: Input required to {prompt}; --no-input was supplied.");
             std::process::exit(INPUT_REQUIRED_EXIT_CODE);
@@ -21,42 +23,49 @@ fn non_interactive_answer(mode: InteractionMode, prompt: &str) -> Option<bool> {
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
-pub fn prompt_overwrite_existing_alias(mode: InteractionMode, alias: &str) -> bool {
-    non_interactive_answer(mode, "overwrite an existing alias").unwrap_or_else(|| {
+fn confirm(mode: InteractionMode, action: &str, message: String, default: bool) -> bool {
+    non_interactive_answer(mode, action).unwrap_or_else(|| {
         Confirm::new()
-            .with_prompt(format!(
-                "Alias \"{alias}\" already exists. Do you want to overwrite it?"
-            ))
-            .default(true)
+            .with_prompt(message)
+            .default(default)
             .interact()
-            .unwrap()
+            .unwrap_or_else(|error| {
+                eprintln!(
+                    "ERROR: Could not prompt to {action}: {error}. Use --yes to accept, --no to decline, or --no-input to fail without prompting."
+                );
+                std::process::exit(INPUT_REQUIRED_EXIT_CODE);
+            })
     })
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
+pub fn prompt_overwrite_existing_alias(mode: InteractionMode, alias: &str) -> bool {
+    confirm(
+        mode,
+        "overwrite an existing alias",
+        format!("Alias \"{alias}\" already exists. Do you want to overwrite it?"),
+        true,
+    )
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_use_non_existing_catalog_file(mode: InteractionMode, path: &str) -> bool {
-    non_interactive_answer(mode, &format!("use missing catalog path '{path}'")).unwrap_or_else(
-        || {
-            Confirm::new()
-                .with_prompt(format!(
-                    "Catalog file '{path}' does not exist. Do you want to use this path anyway?"
-                ))
-                .default(true)
-                .interact()
-                .unwrap()
-        },
+    confirm(
+        mode,
+        &format!("use missing catalog path '{path}'"),
+        format!("Catalog file '{path}' does not exist. Do you want to use this path anyway?"),
+        true,
     )
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_confirm_remove_all(mode: InteractionMode) -> bool {
-    non_interactive_answer(mode, "remove all aliases").unwrap_or_else(|| {
-        Confirm::new()
-            .with_prompt("Are you sure you want to remove all aliases?")
-            .default(false)
-            .interact()
-            .unwrap()
-    })
+    confirm(
+        mode,
+        "remove all aliases",
+        "Are you sure you want to remove all aliases?".into(),
+        false,
+    )
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -75,17 +84,14 @@ pub fn prompt_confirm_remove_tagged_aliases(
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn prompt_confirm_selected_aliases(mode: InteractionMode, count: usize, selection: &str) -> bool {
-    non_interactive_answer(mode, &format!("remove {count} aliases {selection}")).unwrap_or_else(
-        || {
-            Confirm::new()
-                .with_prompt(format!(
-                    "Remove {count} alias{} {selection}?",
-                    if count == 1 { "" } else { "es" },
-                ))
-                .default(false)
-                .interact()
-                .unwrap()
-        },
+    confirm(
+        mode,
+        &format!("remove {count} aliases {selection}"),
+        format!(
+            "Remove {count} alias{} {selection}?",
+            if count == 1 { "" } else { "es" },
+        ),
+        false,
     )
 }
 
@@ -98,6 +104,18 @@ mod tests {
         assert_eq!(
             non_interactive_answer(InteractionMode::Interactive, "continue"),
             None
+        );
+    }
+
+    #[test]
+    fn explicit_modes_supply_their_answer() {
+        assert_eq!(
+            non_interactive_answer(InteractionMode::Yes, "continue"),
+            Some(true)
+        );
+        assert_eq!(
+            non_interactive_answer(InteractionMode::No, "continue"),
+            Some(false)
         );
     }
 }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -48,10 +48,10 @@ pub struct ListCommand {
     /// List only Zsh global aliases
     #[arg(short = 'g', long)]
     pub global: bool,
-    /// Select human-readable or JSON output
-    #[arg(short = 'f', long, value_enum, default_value = "human")]
-    pub format: OutputFormat,
     /// Override configured table columns, in display order
     #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]
     pub columns: Option<Vec<ListColumn>>,
+    /// Select human-readable or JSON output
+    #[arg(short, long, value_enum, default_value = "human")]
+    pub format: OutputFormat,
 }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -39,14 +39,17 @@ pub struct ListCommand {
     /// List aliases containing every supplied tag
     #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
     pub tag: Vec<String>,
-    #[arg(short, long)]
+    /// List only disabled aliases
+    #[arg(short = 'd', long)]
     pub disabled: bool,
     /// List enabled and disabled aliases
     #[arg(long)]
     pub all: bool,
-    #[arg(long)]
+    /// List only Zsh global aliases
+    #[arg(short = 'g', long)]
     pub global: bool,
-    #[arg(long, value_enum, default_value = "human")]
+    /// Select human-readable or JSON output
+    #[arg(short = 'f', long, value_enum, default_value = "human")]
     pub format: OutputFormat,
     /// Override configured table columns, in display order
     #[arg(long, value_enum, value_delimiter = ',', num_args = 1..)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,6 @@
-use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
+use std::collections::{BTreeMap, HashMap};
+
+use clap::{Command, CommandFactory, FromArgMatches, Parser, Subcommand, error::ErrorKind};
 
 pub(crate) mod add;
 pub(crate) mod disable;
@@ -41,34 +43,60 @@ pub fn validate_tag(tag: &str) -> Result<String, String> {
     disable_help_subcommand = true
 )]
 pub struct Cli {
-    #[arg(long, global = true, conflicts_with = "no_input")]
-    pub force: bool,
-    #[arg(long, global = true, conflicts_with = "force")]
-    pub no_input: bool,
-    #[arg(short, long, global = true, conflicts_with_all = ["quiet", "debug"])]
-    pub verbose: bool,
-    #[arg(short, long, global = true, conflicts_with_all = ["verbose", "debug"])]
-    pub quiet: bool,
-    #[arg(long, global = true, conflicts_with_all = ["verbose", "quiet"])]
-    pub debug: bool,
-    #[arg(long, global = true, value_enum)]
+    /// Control when colored output is used
+    #[arg(
+        short = 'c',
+        long,
+        global = true,
+        value_enum,
+        help_heading = "Global Options"
+    )]
     pub color: Option<ColorMode>,
+    /// Show debug diagnostics
+    #[arg(short = 'D', long, global = true, conflicts_with_all = ["verbose", "quiet"], help_heading = "Global Options")]
+    pub debug: bool,
+    /// Automatically decline confirmation prompts
+    #[arg(short = 'n', long, global = true, conflicts_with_all = ["yes", "no_input"], help_heading = "Global Options")]
+    pub no: bool,
+    /// Never prompt; fail when confirmation is required
+    #[arg(short = 'N', long, global = true, conflicts_with_all = ["yes", "no"], help_heading = "Global Options")]
+    pub no_input: bool,
+    /// Suppress normal command output
+    #[arg(short, long, global = true, conflicts_with_all = ["verbose", "debug"], help_heading = "Global Options")]
+    pub quiet: bool,
+    /// Show informational diagnostics
+    #[arg(short, long, global = true, conflicts_with_all = ["quiet", "debug"], help_heading = "Global Options")]
+    pub verbose: bool,
+    /// Automatically accept confirmation prompts
+    #[arg(short = 'y', long, global = true, conflicts_with_all = ["no", "no_input"], help_heading = "Global Options")]
+    pub yes: bool,
     #[command(subcommand)]
     pub command: Commands,
 }
 
 impl Cli {
+    pub fn parse() -> Self {
+        let matches = Self::command().get_matches();
+        Self::from_arg_matches(&matches).unwrap_or_else(|error| error.exit())
+    }
+
+    pub fn command() -> Command {
+        alphabetize_help(<Self as CommandFactory>::command())
+    }
+
     pub fn validate_prompt_controls(&self) -> Result<(), clap::Error> {
-        if self.force && self.no_input {
+        let controls = [
+            ("--yes", self.yes),
+            ("--no", self.no),
+            ("--no-input", self.no_input),
+        ]
+        .into_iter()
+        .filter_map(|(name, enabled)| enabled.then_some(name))
+        .collect::<Vec<_>>();
+        if controls.len() > 1 {
             return Err(Self::command().error(
                 ErrorKind::ArgumentConflict,
-                "--force cannot be used with --no-input",
-            ));
-        }
-        if self.force && matches!(&self.command, Commands::ShellSync(cmd) if cmd.if_changed) {
-            return Err(Self::command().error(
-                ErrorKind::ArgumentConflict,
-                "--force cannot be used with --if-changed",
+                format!("{} cannot be used with {}", controls[0], controls[1]),
             ));
         }
         if matches!(&self.command, Commands::Edit(cmd) if !cmd.has_changes()) {
@@ -79,6 +107,38 @@ impl Cli {
         }
         Ok(())
     }
+}
+
+fn alphabetize_help(mut command: Command) -> Command {
+    let mut headings = BTreeMap::<Option<String>, Vec<(String, String)>>::new();
+    for argument in command
+        .get_arguments()
+        .filter(|argument| !argument.is_positional())
+    {
+        if let Some(long) = argument.get_long() {
+            headings
+                .entry(argument.get_help_heading().map(str::to_owned))
+                .or_default()
+                .push((long.to_owned(), argument.get_id().as_str().to_owned()));
+        }
+    }
+
+    let mut orders = HashMap::new();
+    for arguments in headings.values_mut() {
+        arguments.sort_unstable();
+        for (order, (_, id)) in arguments.iter().enumerate() {
+            orders.insert(id.clone(), order);
+        }
+    }
+
+    command = command.mut_args(|argument| {
+        if let Some(order) = orders.get(argument.get_id().as_str()) {
+            argument.display_order(*order)
+        } else {
+            argument
+        }
+    });
+    command.mut_subcommands(alphabetize_help)
 }
 
 #[derive(Subcommand)]
@@ -170,9 +230,145 @@ mod tests {
         for args in [
             &["aliasmgr", "edit", "ll", "--toggle-enabled"][..],
             &["aliasmgr", "edit", "ll", "--toggle-global"][..],
+            &["aliasmgr", "edit", "ll", "-b"][..],
             &["aliasmgr", "edit", "ll", "--global", "--no-global"][..],
         ] {
             assert!(Cli::try_parse_from(args).is_err(), "{args:?}");
         }
+    }
+
+    #[test]
+    fn help_options_are_sorted_by_long_name_within_each_heading() {
+        fn assert_command(command: &mut Command) {
+            command.build();
+            let help = command.render_help().to_string();
+            let mut heading = None;
+            let mut options = BTreeMap::<String, Vec<String>>::new();
+            for line in help.lines() {
+                if let Some(name) = line.strip_suffix(':') {
+                    heading = Some(name.to_owned());
+                    continue;
+                }
+                let Some(current) = heading.as_ref() else {
+                    continue;
+                };
+                if current == "Arguments" || !line.starts_with("  ") {
+                    continue;
+                }
+                if let Some(long) = line
+                    .split_whitespace()
+                    .find_map(|part| part.strip_prefix("--"))
+                {
+                    if matches!(long, "help" | "version") {
+                        continue;
+                    }
+                    options
+                        .entry(current.clone())
+                        .or_default()
+                        .push(long.trim_end_matches([',', '>']).to_owned());
+                }
+            }
+            for (heading, actual) in options {
+                let mut expected = actual.clone();
+                expected.sort();
+                assert_eq!(actual, expected, "{heading} in {}", command.get_name());
+            }
+            for subcommand in command.get_subcommands_mut() {
+                assert_command(subcommand);
+            }
+        }
+
+        assert_command(&mut Cli::command());
+    }
+
+    #[test]
+    fn flags_have_help_and_unique_short_options_in_every_context() {
+        fn assert_command(command: &Command) {
+            let mut shorts = HashMap::new();
+            for argument in command
+                .get_arguments()
+                .filter(|argument| !argument.is_positional())
+            {
+                assert!(
+                    argument.get_help().is_some(),
+                    "--{} in {} needs help text",
+                    argument.get_long().unwrap_or(argument.get_id().as_str()),
+                    command.get_name()
+                );
+                if let Some(short) = argument.get_short() {
+                    assert!(
+                        shorts.insert(short, argument.get_id()).is_none(),
+                        "duplicate -{short} in {}",
+                        command.get_name()
+                    );
+                }
+                if argument.is_global_set() {
+                    assert_eq!(argument.get_help_heading(), Some("Global Options"));
+                }
+            }
+            for subcommand in command.get_subcommands() {
+                assert_command(subcommand);
+            }
+        }
+
+        let mut command = Cli::command();
+        command.build();
+        assert_command(&command);
+    }
+
+    #[test]
+    fn short_options_match_the_documented_contract() {
+        fn short(command: &Command, long: &str) -> Option<char> {
+            command
+                .get_arguments()
+                .find(|argument| argument.get_long() == Some(long))
+                .and_then(|argument| argument.get_short())
+        }
+
+        let mut command = Cli::command();
+        command.build();
+        for (long, expected) in [
+            ("color", 'c'),
+            ("debug", 'D'),
+            ("no", 'n'),
+            ("no-input", 'N'),
+            ("quiet", 'q'),
+            ("verbose", 'v'),
+            ("yes", 'y'),
+        ] {
+            assert_eq!(short(&command, long), Some(expected));
+        }
+
+        let add = command.find_subcommand("add").unwrap();
+        assert_eq!(short(add, "description"), Some('d'));
+        assert_eq!(short(add, "disabled"), None);
+        assert_eq!(short(add, "global"), Some('g'));
+        assert_eq!(short(add, "tag"), Some('t'));
+
+        let edit = command.find_subcommand("edit").unwrap();
+        assert_eq!(short(edit, "add-tag"), Some('a'));
+        assert_eq!(short(edit, "clear-description"), None);
+        assert_eq!(short(edit, "description"), Some('d'));
+        assert_eq!(short(edit, "global"), Some('g'));
+        assert_eq!(short(edit, "no-global"), None);
+        assert_eq!(short(edit, "remove-tag"), Some('r'));
+        assert!(short(edit, "toggle-enabled").is_none());
+        assert!(short(edit, "toggle-global").is_none());
+
+        let list = command.find_subcommand("list").unwrap();
+        assert_eq!(short(list, "columns"), None);
+        assert_eq!(short(list, "disabled"), Some('d'));
+        assert_eq!(short(list, "format"), Some('f'));
+        assert_eq!(short(list, "global"), Some('g'));
+        assert_eq!(short(list, "tag"), Some('t'));
+        assert!(short(list, "enabled").is_none());
+
+        let remove_alias = command
+            .find_subcommand("remove")
+            .unwrap()
+            .find_subcommand("alias")
+            .unwrap();
+        assert_eq!(short(remove_alias, "pattern"), Some('p'));
+        assert_eq!(short(remove_alias, "tag"), Some('t'));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::{BTreeMap, HashMap};
-
 use clap::{Command, CommandFactory, FromArgMatches, Parser, Subcommand, error::ErrorKind};
 
 pub(crate) mod add;
@@ -52,24 +50,24 @@ pub struct Cli {
         help_heading = "Global Options"
     )]
     pub color: Option<ColorMode>,
-    /// Show debug diagnostics
-    #[arg(short = 'D', long, global = true, conflicts_with_all = ["verbose", "quiet"], help_heading = "Global Options")]
-    pub debug: bool,
-    /// Automatically decline confirmation prompts
-    #[arg(short = 'n', long, global = true, conflicts_with_all = ["yes", "no_input"], help_heading = "Global Options")]
-    pub no: bool,
-    /// Never prompt; fail when confirmation is required
-    #[arg(short = 'N', long, global = true, conflicts_with_all = ["yes", "no"], help_heading = "Global Options")]
-    pub no_input: bool,
     /// Suppress normal command output
     #[arg(short, long, global = true, conflicts_with_all = ["verbose", "debug"], help_heading = "Global Options")]
     pub quiet: bool,
     /// Show informational diagnostics
     #[arg(short, long, global = true, conflicts_with_all = ["quiet", "debug"], help_heading = "Global Options")]
     pub verbose: bool,
+    /// Show debug diagnostics
+    #[arg(short = 'D', long, global = true, conflicts_with_all = ["verbose", "quiet"], help_heading = "Global Options")]
+    pub debug: bool,
     /// Automatically accept confirmation prompts
     #[arg(short = 'y', long, global = true, conflicts_with_all = ["no", "no_input"], help_heading = "Global Options")]
     pub yes: bool,
+    /// Automatically decline confirmation prompts
+    #[arg(short = 'n', long, global = true, conflicts_with_all = ["yes", "no_input"], help_heading = "Global Options")]
+    pub no: bool,
+    /// Never prompt; fail when confirmation is required
+    #[arg(short = 'N', long, global = true, conflicts_with_all = ["yes", "no"], help_heading = "Global Options")]
+    pub no_input: bool,
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -81,7 +79,7 @@ impl Cli {
     }
 
     pub fn command() -> Command {
-        alphabetize_help(<Self as CommandFactory>::command())
+        <Self as CommandFactory>::command()
     }
 
     pub fn validate_prompt_controls(&self) -> Result<(), clap::Error> {
@@ -107,38 +105,6 @@ impl Cli {
         }
         Ok(())
     }
-}
-
-fn alphabetize_help(mut command: Command) -> Command {
-    let mut headings = BTreeMap::<Option<String>, Vec<(String, String)>>::new();
-    for argument in command
-        .get_arguments()
-        .filter(|argument| !argument.is_positional())
-    {
-        if let Some(long) = argument.get_long() {
-            headings
-                .entry(argument.get_help_heading().map(str::to_owned))
-                .or_default()
-                .push((long.to_owned(), argument.get_id().as_str().to_owned()));
-        }
-    }
-
-    let mut orders = HashMap::new();
-    for arguments in headings.values_mut() {
-        arguments.sort_unstable();
-        for (order, (_, id)) in arguments.iter().enumerate() {
-            orders.insert(id.clone(), order);
-        }
-    }
-
-    command = command.mut_args(|argument| {
-        if let Some(order) = orders.get(argument.get_id().as_str()) {
-            argument.display_order(*order)
-        } else {
-            argument
-        }
-    });
-    command.mut_subcommands(alphabetize_help)
 }
 
 #[derive(Subcommand)]
@@ -178,6 +144,8 @@ pub enum Commands {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -238,47 +206,71 @@ mod tests {
     }
 
     #[test]
-    fn help_options_are_sorted_by_long_name_within_each_heading() {
-        fn assert_command(command: &mut Command) {
+    fn help_options_are_ordered_by_meaning() {
+        fn options(command: &mut Command, heading: &str) -> Vec<String> {
             command.build();
             let help = command.render_help().to_string();
-            let mut heading = None;
-            let mut options = BTreeMap::<String, Vec<String>>::new();
+            let mut current_heading = None;
+            let mut options = Vec::new();
             for line in help.lines() {
                 if let Some(name) = line.strip_suffix(':') {
-                    heading = Some(name.to_owned());
+                    current_heading = Some(name);
                     continue;
                 }
-                let Some(current) = heading.as_ref() else {
-                    continue;
-                };
-                if current == "Arguments" || !line.starts_with("  ") {
+                if current_heading != Some(heading) || !line.starts_with("  ") {
                     continue;
                 }
                 if let Some(long) = line
                     .split_whitespace()
                     .find_map(|part| part.strip_prefix("--"))
                 {
-                    if matches!(long, "help" | "version") {
-                        continue;
+                    let long = long.trim_end_matches([',', '>']);
+                    if !matches!(long, "help" | "version") {
+                        options.push(long.to_owned());
                     }
-                    options
-                        .entry(current.clone())
-                        .or_default()
-                        .push(long.trim_end_matches([',', '>']).to_owned());
                 }
             }
-            for (heading, actual) in options {
-                let mut expected = actual.clone();
-                expected.sort();
-                assert_eq!(actual, expected, "{heading} in {}", command.get_name());
-            }
-            for subcommand in command.get_subcommands_mut() {
-                assert_command(subcommand);
-            }
+            options
         }
 
-        assert_command(&mut Cli::command());
+        let mut command = Cli::command();
+        command.build();
+        assert_eq!(
+            options(&mut command, "Global Options"),
+            [
+                "color", "quiet", "verbose", "debug", "yes", "no", "no-input"
+            ]
+        );
+        assert_eq!(
+            options(command.find_subcommand_mut("add").unwrap(), "Options"),
+            ["global", "tag", "description", "disabled"]
+        );
+        assert_eq!(
+            options(command.find_subcommand_mut("edit").unwrap(), "Options"),
+            [
+                "add-tag",
+                "remove-tag",
+                "description",
+                "clear-description",
+                "global",
+                "no-global",
+            ]
+        );
+        assert_eq!(
+            options(command.find_subcommand_mut("list").unwrap(), "Options"),
+            ["tag", "disabled", "all", "global", "columns", "format"]
+        );
+        assert_eq!(
+            options(
+                command
+                    .find_subcommand_mut("remove")
+                    .unwrap()
+                    .find_subcommand_mut("alias")
+                    .unwrap(),
+                "Options",
+            ),
+            ["pattern", "tag"]
+        );
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,6 +105,12 @@ impl Cli {
                 "--yes cannot be used with --skip-existing",
             ));
         }
+        if self.no && matches!(&self.command, Commands::Import(cmd) if cmd.replace_existing) {
+            return Err(Self::command().error(
+                ErrorKind::ArgumentConflict,
+                "--no cannot be used with --replace-existing",
+            ));
+        }
         if matches!(&self.command, Commands::Edit(cmd) if !cmd.has_changes()) {
             return Err(Self::command().error(
                 ErrorKind::MissingRequiredArgument,
@@ -269,6 +275,10 @@ mod tests {
             ]
         );
         assert_eq!(
+            options(command.find_subcommand_mut("import").unwrap(), "Options"),
+            ["dry-run", "skip-existing", "replace-existing", "tag"]
+        );
+        assert_eq!(
             options(command.find_subcommand_mut("list").unwrap(), "Options"),
             ["tag", "disabled", "all", "global", "columns", "format"]
         );
@@ -288,14 +298,7 @@ mod tests {
     #[test]
     fn import_parses_multiple_paths_tags_and_collision_policy() {
         let cli = Cli::try_parse_from([
-            "aliasmgr",
-            "import",
-            ".bashrc",
-            ".zshrc",
-            "--tag",
-            "shell",
-            "--dry-run",
-            "--replace-existing",
+            "aliasmgr", "import", ".bashrc", ".zshrc", "-t", "shell", "-d", "-r",
         ])
         .unwrap();
         assert!(
@@ -385,6 +388,12 @@ mod tests {
         assert_eq!(short(list, "tag"), Some('t'));
         assert!(short(list, "enabled").is_none());
 
+        let import = command.find_subcommand("import").unwrap();
+        assert_eq!(short(import, "dry-run"), Some('d'));
+        assert_eq!(short(import, "skip-existing"), Some('s'));
+        assert_eq!(short(import, "replace-existing"), Some('r'));
+        assert_eq!(short(import, "tag"), Some('t'));
+
         let remove_alias = command
             .find_subcommand("remove")
             .unwrap()
@@ -407,11 +416,15 @@ mod tests {
             .is_err()
         );
 
-        let cli = Cli::try_parse_from(["aliasmgr", "--yes", "import", ".zshrc", "--skip-existing"])
-            .unwrap();
-        assert_eq!(
-            cli.validate_prompt_controls().unwrap_err().kind(),
-            ErrorKind::ArgumentConflict
-        );
+        for args in [
+            &["aliasmgr", "--yes", "import", ".zshrc", "--skip-existing"][..],
+            &["aliasmgr", "--no", "import", ".zshrc", "--replace-existing"][..],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert_eq!(
+                cli.validate_prompt_controls().unwrap_err().kind(),
+                ErrorKind::ArgumentConflict
+            );
+        }
     }
 }

--- a/src/cli/selector.rs
+++ b/src/cli/selector.rs
@@ -7,7 +7,8 @@ use super::validate_tag;
 pub struct AliasSelectorArgs {
     #[arg(conflicts_with_all = ["pattern", "tag"])]
     pub name: Option<String>,
-    #[arg(long, value_name = "GLOB", value_parser = validate_glob)]
+    /// Select aliases whose names match a glob
+    #[arg(short = 'p', long, value_name = "GLOB", value_parser = validate_glob)]
     pub pattern: Option<String>,
     /// Select aliases containing every supplied tag
     #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]

--- a/src/cli/sync.rs
+++ b/src/cli/sync.rs
@@ -5,6 +5,9 @@ pub struct SyncCommand {}
 
 #[derive(Args)]
 pub struct ShellSyncCommand {
+    /// Reconcile even when this terminal already has the current revision
+    #[arg(long, conflicts_with = "if_changed")]
+    pub force: bool,
     /// Skip reconciliation when this terminal already has the current revision
     #[arg(long, conflicts_with = "force")]
     pub if_changed: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use clap::ValueEnum;
-use log::warn;
+use env_logger::WriteStyle;
 use owo_colors::{DynColors, Style};
 use serde::Deserialize;
 
@@ -29,6 +29,14 @@ impl ColorMode {
             Self::Auto => std::io::stdout().is_terminal() && env::var_os("NO_COLOR").is_none(),
             Self::Always => true,
             Self::Never => false,
+        }
+    }
+
+    pub fn write_style(self) -> WriteStyle {
+        match self {
+            Self::Auto => WriteStyle::Auto,
+            Self::Always => WriteStyle::Always,
+            Self::Never => WriteStyle::Never,
         }
     }
 }
@@ -132,6 +140,12 @@ pub struct UserConfig {
     pub list: ListConfig,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct LoadedConfig {
+    pub config: UserConfig,
+    pub warnings: Vec<String>,
+}
+
 #[derive(Default, Deserialize)]
 #[serde(default)]
 struct RawConfig {
@@ -189,21 +203,32 @@ struct RawStateStyle {
     unknown: BTreeMap<String, toml::Value>,
 }
 
-fn warn_unknown(section: Option<&str>, fields: &BTreeMap<String, toml::Value>) {
+fn collect_unknown_warnings(
+    section: Option<&str>,
+    fields: &BTreeMap<String, toml::Value>,
+    warnings: &mut Vec<String>,
+) {
     for name in fields.keys() {
         if let Some(section) = section {
-            warn!("Unknown configuration setting '{section}.{name}' ignored.");
+            warnings.push(format!(
+                "Unknown configuration setting '{section}.{name}' ignored."
+            ));
         } else {
-            warn!("Unknown configuration setting '{name}' ignored.");
+            warnings.push(format!("Unknown configuration setting '{name}' ignored."));
         }
     }
 }
 
-fn apply_style(name: &str, target: &mut StateStyle, raw: Option<RawStateStyle>) -> Result<()> {
+fn apply_style(
+    name: &str,
+    target: &mut StateStyle,
+    raw: Option<RawStateStyle>,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
     let Some(raw) = raw else {
         return Ok(());
     };
-    warn_unknown(Some(&format!("styles.{name}")), &raw.unknown);
+    collect_unknown_warnings(Some(&format!("styles.{name}")), &raw.unknown, warnings);
     if let Some(foreground) = raw.foreground {
         foreground.parse::<DynColors>().map_err(|_| {
             anyhow::anyhow!(
@@ -218,13 +243,14 @@ fn apply_style(name: &str, target: &mut StateStyle, raw: Option<RawStateStyle>) 
     Ok(())
 }
 
-fn parse_config(content: &str) -> Result<UserConfig> {
+fn parse_config_with_warnings(content: &str) -> Result<LoadedConfig> {
     let raw: RawConfig = toml::from_str(content)?;
-    warn_unknown(None, &raw.unknown);
-    warn_unknown(Some("color"), &raw.color.unknown);
-    warn_unknown(Some("symbols"), &raw.symbols.unknown);
-    warn_unknown(Some("styles"), &raw.styles.unknown);
-    warn_unknown(Some("list"), &raw.list.unknown);
+    let mut warnings = Vec::new();
+    collect_unknown_warnings(None, &raw.unknown, &mut warnings);
+    collect_unknown_warnings(Some("color"), &raw.color.unknown, &mut warnings);
+    collect_unknown_warnings(Some("symbols"), &raw.symbols.unknown, &mut warnings);
+    collect_unknown_warnings(Some("styles"), &raw.styles.unknown, &mut warnings);
+    collect_unknown_warnings(Some("list"), &raw.list.unknown, &mut warnings);
 
     let mut config = UserConfig::default();
     if let Some(mode) = raw.color.mode {
@@ -240,9 +266,13 @@ fn parse_config(content: &str) -> Result<UserConfig> {
         config.symbols.global = global;
     }
 
-    apply_style("enabled", &mut config.styles.enabled, raw.styles.enabled)?;
-    apply_style("disabled", &mut config.styles.disabled, raw.styles.disabled)?;
-    apply_style("global", &mut config.styles.global, raw.styles.global)?;
+    for (name, target, style) in [
+        ("enabled", &mut config.styles.enabled, raw.styles.enabled),
+        ("disabled", &mut config.styles.disabled, raw.styles.disabled),
+        ("global", &mut config.styles.global, raw.styles.global),
+    ] {
+        apply_style(name, target, style, &mut warnings)?;
+    }
     if let Some(columns) = raw.list.columns {
         if columns.is_empty() {
             bail!("'list.columns' must contain at least one column");
@@ -259,7 +289,12 @@ fn parse_config(content: &str) -> Result<UserConfig> {
     if let Some(status) = raw.list.status {
         config.list.status = status;
     }
-    Ok(config)
+    Ok(LoadedConfig { config, warnings })
+}
+
+#[cfg(test)]
+fn parse_config(content: &str) -> Result<UserConfig> {
+    Ok(parse_config_with_warnings(content)?.config)
 }
 
 pub fn config_path(path: Option<&Path>) -> PathBuf {
@@ -272,24 +307,29 @@ pub fn config_path(path: Option<&Path>) -> PathBuf {
     })
 }
 
+#[cfg(test)]
 fn load_config_from(path: &Path, required: bool) -> Result<UserConfig> {
+    Ok(load_config_from_with_warnings(path, required)?.config)
+}
+
+fn load_config_from_with_warnings(path: &Path, required: bool) -> Result<LoadedConfig> {
     if !path.exists() {
         if required {
             bail!("configured file '{}' does not exist", path.display());
         }
-        return Ok(UserConfig::default());
+        return Ok(LoadedConfig::default());
     }
 
     let content = fs::read_to_string(path)
         .with_context(|| format!("could not read configuration '{}'", path.display()))?;
-    parse_config(&content)
+    parse_config_with_warnings(&content)
         .with_context(|| format!("could not parse configuration '{}'", path.display()))
 }
 
-pub fn load_config() -> Result<UserConfig> {
+pub fn load_config() -> Result<LoadedConfig> {
     let explicit = env::var_os(CONFIG_FILE_ENV_VAR).map(PathBuf::from);
     let path = config_path(explicit.as_deref());
-    load_config_from(&path, explicit.is_some())
+    load_config_from_with_warnings(&path, explicit.is_some())
 }
 
 #[cfg(test)]
@@ -336,7 +376,7 @@ mod tests {
 
     #[test]
     fn unknown_settings_are_accepted() {
-        let config = parse_config(
+        let loaded = parse_config_with_warnings(
             r#"
             future = true
             [symbols]
@@ -345,7 +385,14 @@ mod tests {
             "#,
         )
         .unwrap();
-        assert_eq!(config.symbols.enabled, "+");
+        assert_eq!(loaded.config.symbols.enabled, "+");
+        assert_eq!(
+            loaded.warnings,
+            [
+                "Unknown configuration setting 'future' ignored.",
+                "Unknown configuration setting 'symbols.future' ignored.",
+            ]
+        );
     }
 
     #[test]
@@ -404,6 +451,9 @@ mod tests {
     fn color_mode_respects_explicit_modes() {
         assert!(ColorMode::Always.enabled());
         assert!(!ColorMode::Never.enabled());
+        assert_eq!(ColorMode::Auto.write_style(), WriteStyle::Auto);
+        assert_eq!(ColorMode::Always.write_style(), WriteStyle::Always);
+        assert_eq!(ColorMode::Never.write_style(), WriteStyle::Never);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,6 @@ mod cli;
 mod config;
 mod core;
 
-use clap::Parser;
-
 use cli::interaction::InteractionMode;
 use cli::{Cli, Commands};
 use config::load_config;
@@ -23,7 +21,7 @@ use app::disable::handle_disable;
 use app::doctor::handle_doctor;
 use app::edit::handle_edit;
 use app::enable::handle_enable;
-use app::file_path::determine_catalog_path;
+use app::file_path::{CatalogPathDecision, determine_catalog_path};
 use app::init::handle_init;
 use app::list::handle_list;
 use app::remove::handle_remove;
@@ -41,15 +39,26 @@ fn main() {
         error.exit();
     }
     let quiet = cli.quiet;
-    let interaction_mode = if cli.force {
-        InteractionMode::Force
+    let interaction_mode = if cli.yes {
+        InteractionMode::Yes
+    } else if cli.no {
+        InteractionMode::No
     } else if cli.no_input {
         InteractionMode::NoInput
     } else {
         InteractionMode::Interactive
     };
 
-    // Determine log level based on CLI flags
+    let loaded_config = match load_config() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("ERROR: {error:#}");
+            std::process::exit(1);
+        }
+    };
+    let config = loaded_config.config;
+    let color_mode = cli.color.unwrap_or(config.color);
+
     let level = if cli.quiet {
         LevelFilter::Error
     } else if cli.verbose {
@@ -65,16 +74,13 @@ fn main() {
         .format_target(false)
         .filter_level(level)
         .parse_default_env()
+        .write_style(color_mode.write_style())
         .init();
 
-    let config = match load_config() {
-        Ok(config) => config,
-        Err(error) => {
-            eprintln!("ERROR: {error:#}");
-            std::process::exit(1);
-        }
-    };
-    let colors_enabled = cli.color.unwrap_or(config.color).enabled();
+    for warning in loaded_config.warnings {
+        log::warn!("{warning}");
+    }
+    let colors_enabled = color_mode.enabled();
 
     let mut catalog = AliasCatalog::new();
     let mut catalog_path = None;
@@ -86,8 +92,15 @@ fn main() {
         shell = determine_shell();
         debug!("Determined shell: {}", shell);
 
-        catalog_path = determine_catalog_path(interaction_mode)
-            .expect("Custom catalog path did not exist and user chose not to use it.");
+        catalog_path = match determine_catalog_path(interaction_mode) {
+            CatalogPathDecision::Use(path) => path,
+            CatalogPathDecision::Decline => {
+                if !quiet {
+                    println!("Catalog path was declined. No changes made.");
+                }
+                return;
+            }
+        };
         debug!("Using catalog path: {:?}", catalog_path);
 
         let resolved_catalog_path = resolve_catalog_path(catalog_path.as_ref());
@@ -119,10 +132,7 @@ fn main() {
         Commands::Doctor(_) => handle_doctor(&catalog, &shell, quiet).map(CommandOutcome::from),
         Commands::Sync(_) => handle_sync().map(CommandOutcome::from),
         Commands::ShellSync(cmd) => {
-            print!(
-                "{}",
-                handle_shell_sync(&catalog, &shell, cmd, interaction_mode)
-            );
+            print!("{}", handle_shell_sync(&catalog, &shell, cmd));
             Ok(CommandOutcome::from(Outcome::NoChanges))
         }
         Commands::Init(cmd) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
         }
         Commands::Rename(cmd) => handle_rename(&mut catalog, cmd),
         Commands::Edit(cmd) => handle_edit(&mut catalog, cmd, &shell).map(CommandOutcome::from),
-        Commands::Import(cmd) => handle_import(&mut catalog, cmd, interaction_mode, cli.yes),
+        Commands::Import(cmd) => handle_import(&mut catalog, cmd, interaction_mode),
         Commands::Enable(cmd) => handle_enable(&mut catalog, cmd),
         Commands::Disable(cmd) => handle_disable(&mut catalog, cmd),
         Commands::Doctor(_) => handle_doctor(&catalog, &shell, quiet).map(CommandOutcome::from),

--- a/tests/bulk_filters.rs
+++ b/tests/bulk_filters.rs
@@ -86,9 +86,9 @@ fn tag_removal_can_delete_tagged_aliases_after_one_confirmation() {
     assert!(String::from_utf8_lossy(&no_input.stderr).contains("remove 2 aliases tagged 'dev'"));
     assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
 
-    let force = run_aliasmgr(&catalog, &["remove", "tag", "dev", "--aliases", "--force"]);
-    assert!(force.status.success(), "{force:?}");
-    assert_eq!(stdout(&force), "Removed 2 of 2 aliases tagged 'dev'.");
+    let yes = run_aliasmgr(&catalog, &["remove", "tag", "dev", "--aliases", "--yes"]);
+    assert!(yes.status.success(), "{yes:?}");
+    assert_eq!(stdout(&yes), "Removed 2 of 2 aliases tagged 'dev'.");
     let content = fs::read_to_string(&catalog).unwrap();
     assert!(!content.contains("build ="));
     assert!(!content.contains("test ="));
@@ -110,9 +110,9 @@ fn filtered_remove_prompts_once_and_empty_matches_are_noops() {
     );
     assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
 
-    let force = run_aliasmgr(&catalog, &["remove", "alias", "--tag", "dev", "--force"]);
-    assert!(force.status.success());
-    assert_eq!(stdout(&force), "Removed 2 of 2 matching aliases.");
+    let yes = run_aliasmgr(&catalog, &["remove", "alias", "--tag", "dev", "--yes"]);
+    assert!(yes.status.success());
+    assert_eq!(stdout(&yes), "Removed 2 of 2 matching aliases.");
 
     fs::write(&catalog, "ll = \"ls -la\"\n").unwrap();
     let empty = run_aliasmgr(&catalog, &["enable", "alias", "--tag", "missing"]);

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -83,3 +83,27 @@ fn unknown_configuration_settings_warn_without_blocking() {
             .contains("Unknown configuration setting 'future' ignored.")
     );
 }
+
+#[test]
+fn resolved_color_mode_controls_logger_styling() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let config = directory.path().join("config.toml");
+    fs::write(&catalog, "ll = \"ls -la\"\n").unwrap();
+    fs::write(&config, "future = true\n[color]\nmode = \"always\"\n").unwrap();
+
+    for (mode, colored) in [("auto", false), ("always", true), ("never", false)] {
+        let output = run_aliasmgr(&catalog, &config, &["list", "-c", mode]);
+        assert!(output.status.success(), "{mode}: {output:?}");
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(stderr.contains("Unknown configuration setting 'future' ignored."));
+        assert_eq!(stderr.contains("\u{1b}["), colored, "{mode}: {stderr:?}");
+    }
+
+    let configured = run_aliasmgr(&catalog, &config, &["list"]);
+    assert!(
+        String::from_utf8(configured.stderr)
+            .unwrap()
+            .contains("\u{1b}[")
+    );
+}

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -31,7 +31,7 @@ fn imports_bash_and_zsh_aliases_from_multiple_files() {
             "import",
             bash.to_str().unwrap(),
             zsh.to_str().unwrap(),
-            "--tag",
+            "-t",
             "shell",
         ],
     );
@@ -65,10 +65,7 @@ fn collision_policies_preserve_identical_aliases_and_replace_differences() {
     )
     .unwrap();
 
-    let skipped = run_aliasmgr(
-        &catalog,
-        &["import", source.to_str().unwrap(), "--skip-existing"],
-    );
+    let skipped = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "-s"]);
     assert!(skipped.status.success(), "{skipped:?}");
     assert!(
         String::from_utf8_lossy(&skipped.stdout)
@@ -77,10 +74,7 @@ fn collision_policies_preserve_identical_aliases_and_replace_differences() {
     assert!(String::from_utf8_lossy(&skipped.stdout).contains("1 aliases unchanged"));
     assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
 
-    let replaced = run_aliasmgr(
-        &catalog,
-        &["import", source.to_str().unwrap(), "--replace-existing"],
-    );
+    let replaced = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "-r", "-N"]);
     assert!(replaced.status.success(), "{replaced:?}");
     let content = fs::read_to_string(&catalog).unwrap();
     assert!(content.contains("gs = \"git status --short\""));
@@ -90,12 +84,12 @@ fn collision_policies_preserve_identical_aliases_and_replace_differences() {
 }
 
 #[test]
-fn force_aliases_replace_and_no_input_requires_a_policy() {
+fn prompt_modes_alias_collision_policies_and_no_input_requires_a_policy() {
     let directory = tempfile::tempdir().unwrap();
     let catalog = directory.path().join("aliases.toml");
     let source = directory.path().join("aliases");
     fs::write(&catalog, "ll = \"ls\"\n").unwrap();
-    fs::write(&source, "alias ll='ls -la'\n").unwrap();
+    fs::write(&source, "alias ll='ls -la'\nalias gs='git status'\n").unwrap();
 
     let refused = run_aliasmgr(
         &catalog,
@@ -104,9 +98,18 @@ fn force_aliases_replace_and_no_input_requires_a_policy() {
     assert_eq!(refused.status.code(), Some(2));
     assert_eq!(fs::read_to_string(&catalog).unwrap(), "ll = \"ls\"\n");
 
-    let replaced = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "--force"]);
+    let skipped = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "--no"]);
+    assert!(skipped.status.success(), "{skipped:?}");
+    let content = fs::read_to_string(&catalog).unwrap();
+    assert!(content.contains("ll = \"ls\""));
+    assert!(content.contains("gs = \"git status\""));
+
+    fs::write(&catalog, "ll = \"ls\"\n").unwrap();
+    let replaced = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "--yes"]);
     assert!(replaced.status.success(), "{replaced:?}");
-    assert_eq!(fs::read_to_string(&catalog).unwrap(), "ll = \"ls -la\"\n");
+    let content = fs::read_to_string(&catalog).unwrap();
+    assert!(content.contains("ll = \"ls -la\""));
+    assert!(content.contains("gs = \"git status\""));
 }
 
 #[test]
@@ -118,12 +121,21 @@ fn dry_run_reports_without_prompting_or_writing() {
     fs::write(&catalog, original).unwrap();
     fs::write(&source, "alias ll='ls -la'\nalias gs='git status'\n").unwrap();
 
-    let output = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "--dry-run"]);
+    let output = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "-d"]);
     assert!(output.status.success(), "{output:?}");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Dry run: 1 aliases would be imported"));
     assert!(stdout.contains("1 collisions found"));
     assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+
+    for (mode, result) in [("--yes", "replaced"), ("--no", "skipped")] {
+        let output = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "-d", mode]);
+        assert!(output.status.success(), "{mode}: {output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stdout)
+                .contains(&format!("1 collisions found and would be {result}"))
+        );
+    }
 
     let skipped = run_aliasmgr(
         &catalog,

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -133,24 +133,27 @@ fn add_edit_and_json_listing_preserve_metadata() {
             "add",
             "test",
             "cargo test",
-            "--description",
+            "-d",
             "Run tests",
-            "--tag",
+            "-t",
             "rust",
             "--tag",
             "dev",
             "--tag",
             "rust",
+            "--disabled",
         ],
     );
     assert!(add.status.success(), "{add:?}");
     let content = fs::read_to_string(&catalog).unwrap();
     assert!(content.contains("description = \"Run tests\""));
+    assert!(content.contains("enabled = false"));
     assert!(content.contains("tags = [\"dev\", \"rust\"]"));
 
-    let json = run_aliasmgr(&catalog, &["list", "--format", "json"]);
+    let json = run_aliasmgr(&catalog, &["list", "--all", "-f", "json"]);
     let value: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
     assert_eq!(value[0]["description"], "Run tests");
+    assert_eq!(value[0]["enabled"], false);
     assert_eq!(value[0]["tags"], serde_json::json!(["dev", "rust"]));
 
     let edit = run_aliasmgr(

--- a/tests/non_interactive.rs
+++ b/tests/non_interactive.rs
@@ -19,12 +19,12 @@ fn assert_input_required(output: &Output, action: &str) {
 }
 
 #[test]
-fn force_accepts_overwrite_and_remove_all() {
+fn yes_accepts_overwrite_and_remove_all() {
     let directory = tempfile::tempdir().unwrap();
     let catalog = directory.path().join("aliases.toml");
     fs::write(&catalog, "ll = \"ls\"\n").unwrap();
     assert!(
-        run_aliasmgr(&catalog, &["add", "ll", "ls -la", "--force"])
+        run_aliasmgr(&catalog, &["add", "ll", "ls -la", "--yes"])
             .status
             .success()
     );
@@ -34,11 +34,27 @@ fn force_accepts_overwrite_and_remove_all() {
             .contains("ll = \"ls -la\"")
     );
     assert!(
-        run_aliasmgr(&catalog, &["remove", "all", "--force"])
+        run_aliasmgr(&catalog, &["remove", "all", "-y"])
             .status
             .success()
     );
     assert_eq!(fs::read_to_string(&catalog).unwrap(), "");
+}
+
+#[test]
+fn no_declines_prompts_without_changes() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original = "ll = \"ls\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    let overwrite = run_aliasmgr(&catalog, &["add", "ll", "ls -la", "--no"]);
+    assert!(overwrite.status.success(), "{overwrite:?}");
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+
+    let remove = run_aliasmgr(&catalog, &["remove", "all", "-n"]);
+    assert!(remove.status.success(), "{remove:?}");
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
 }
 
 #[test]
@@ -49,7 +65,7 @@ fn no_input_refuses_prompts_without_changes() {
     let overwrite = run_aliasmgr(&catalog, &["add", "ll", "ls -la", "--no-input"]);
     assert_input_required(&overwrite, "overwrite an existing alias");
     assert_eq!(fs::read_to_string(&catalog).unwrap(), "ll = \"ls\"\n");
-    let remove = run_aliasmgr(&catalog, &["remove", "all", "--no-input"]);
+    let remove = run_aliasmgr(&catalog, &["remove", "all", "-N"]);
     assert_input_required(&remove, "remove all aliases");
     assert_eq!(fs::read_to_string(&catalog).unwrap(), "ll = \"ls\"\n");
 }
@@ -82,11 +98,75 @@ fn prompt_controls_conflict_across_command_scopes() {
     let directory = tempfile::tempdir().unwrap();
     let catalog = directory.path().join("aliases.toml");
     fs::write(&catalog, "").unwrap();
-    let output = run_aliasmgr(&catalog, &["--force", "list", "--no-input"]);
-    assert_eq!(output.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("--force cannot be used with --no-input")
-    );
-    let shell_sync = run_aliasmgr(&catalog, &["--force", "shell-sync", "--if-changed"]);
+    for args in [
+        &["--yes", "list", "--no"][..],
+        &["--no", "list", "--no-input"][..],
+        &["--yes", "list", "--no-input"][..],
+    ] {
+        let output = run_aliasmgr(&catalog, args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+    }
+
+    let shell_sync = run_aliasmgr(&catalog, &["shell-sync", "--force", "--if-changed"]);
     assert_eq!(shell_sync.status.code(), Some(2));
+}
+
+#[test]
+fn non_terminal_prompt_fails_cleanly_without_changes() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original = "ll = \"ls\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    let output = run_aliasmgr(&catalog, &["add", "ll", "ls -la"]);
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Could not prompt to overwrite an existing alias"));
+    assert!(stderr.contains("--yes"));
+    assert!(stderr.contains("--no"));
+    assert!(stderr.contains("--no-input"));
+    assert!(!stderr.contains("panicked"));
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+}
+
+#[test]
+fn declining_a_missing_catalog_path_is_a_successful_noop() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("missing.toml");
+
+    let output = run_aliasmgr(&catalog, &["list", "--no"]);
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "Catalog path was declined. No changes made.\n"
+    );
+    assert!(!catalog.exists());
+}
+
+#[test]
+fn yes_does_not_force_shell_reconciliation() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "ll = \"ls -la\"\n").unwrap();
+
+    let forced = run_aliasmgr(&catalog, &["shell-sync", "--force"]);
+    assert!(forced.status.success(), "{forced:?}");
+    let script = String::from_utf8(forced.stdout).unwrap();
+    let revision = script
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("    __aliasmgr_catalog_revision='")
+                .and_then(|value| value.strip_suffix('\''))
+        })
+        .unwrap();
+
+    let if_changed = Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(["--yes", "shell-sync", "--if-changed"])
+        .env("ALIASMGR_CATALOG_PATH", &catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .env("ALIASMGR_CATALOG_REVISION", revision)
+        .output()
+        .unwrap();
+    assert!(if_changed.status.success(), "{if_changed:?}");
+    assert!(if_changed.stdout.is_empty());
 }

--- a/tests/shell_integration.rs
+++ b/tests/shell_integration.rs
@@ -81,7 +81,7 @@ __aliasmgr_prompt_sync
 alias build >/dev/null || exit 26
 alias bench >/dev/null || exit 27
 
-remove_output="$(aliasmgr remove alias --pattern 'b*' --tag rust --force)"
+remove_output="$(aliasmgr remove alias -p 'b*' -t rust --yes)"
 [ "$remove_output" = 'Removed 2 of 2 matching aliases.' ] || exit 28
 __aliasmgr_prompt_sync
 ! alias build 2>/dev/null || exit 29


### PR DESCRIPTION
## Summary

- replace global `--force` prompt handling with mutually exclusive `--yes`, `--no`, and `--no-input` modes, including clean non-terminal errors
- keep the explicit edit/list state API from PR #35 while adding collision-free short options, per-flag help text, and help groups ordered by purpose
- align the imported alias collision policies from PR #38 so `--yes` behaves like `--replace-existing`, `--no` behaves like `--skip-existing`, and import exposes `-d`, `-s`, `-r`, and `-t`
- move reconciliation forcing to hidden `shell-sync --force` and apply the resolved color mode to logger styling without losing configuration warnings

## Acceptance criteria

- confirmation modes accept, decline, or fail without modifying state outside their documented behavior
- inherited flags appear under `Global Options`, related options stay together in a meaningful order, and positional/help/version ordering remains conventional
- documented global and command-specific short forms work without collisions; removed edit toggles and redundant `list --enabled` remain rejected
- import collision policies compose predictably with global prompt modes and reject contradictory combinations
- configured and CLI-overridden color modes consistently control application and logger output

## Validation

- `cargo build --verbose`
- `cargo test` (128 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo +nightly llvm-cov --all-features --workspace --lcov --output-path /private/tmp/aliasmgr-issue36-merged-lcov.info` (128 passed; 98.33% line coverage)

Closes #36
