### PR TITLE
Add shell alias import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ status = "auto"
 
 - `aliasmgr add <name> <command> [--description <text>] [--tag <tag>]... [--disabled] [--global]`
 - `aliasmgr edit <name> [command] [--description <text> | --clear-description] [--add-tag <tag>]... [--remove-tag <tag>]... [--global | --no-global]`
+- `aliasmgr import <path>... [--tag <tag>]... [--dry-run] [--skip-existing | --replace-existing]`
 - `aliasmgr list [pattern] [--tag <tag>]... [--disabled | --all] [--global] [--columns <columns>] [--format <human|json>]`
 - `aliasmgr remove <name>`
 - `aliasmgr remove alias <name>`
@@ -105,6 +106,7 @@ For more details, use `-h` or `--help`.
 Notes:
 
 - Repeat `--tag` when creating an alias or filtering by multiple tags. Filters use AND semantics: every supplied tag must be present.
+- `import` reads ordinary Bash and Zsh alias declarations from one or more files. Unsupported lines are skipped. Existing aliases prompt before replacement and default to being kept; use `--skip-existing` to keep them non-interactively, or `--replace-existing`/`--force` to replace them. `--dry-run` reports counts without prompting or changing the catalog.
 - `list` shows enabled aliases by default. Use `--disabled` for disabled aliases or `--all` for both.
 - Tags are case-sensitive and cannot be empty or contain whitespace.
 - `--force` and `--no-input` are mutually exclusive global automation flags. `--force` accepts overwrite and removal prompts; `--no-input` exits with status 2 if input would be required.

--- a/src/app/import.rs
+++ b/src/app/import.rs
@@ -1,0 +1,155 @@
+use std::fs;
+
+use log::warn;
+
+use crate::catalog::types::{Alias, AliasCatalog};
+use crate::cli::import::ImportCommand;
+use crate::cli::interaction::{InteractionMode, prompt_replace_imported_alias};
+use crate::core::import::{ParsedLine, is_identical, parse_alias_line};
+use crate::core::{Failure, Outcome};
+
+use super::CommandOutcome;
+
+#[derive(Clone, Copy)]
+enum CollisionPolicy {
+    Prompt,
+    Skip,
+    Replace,
+}
+
+#[derive(Default)]
+struct ImportSummary {
+    imported: usize,
+    collisions: usize,
+    replaced: usize,
+    skipped_collisions: usize,
+    unsupported: usize,
+    unchanged: usize,
+}
+
+pub fn handle_import(
+    catalog: &mut AliasCatalog,
+    args: ImportCommand,
+    interaction_mode: InteractionMode,
+    force: bool,
+) -> Result<CommandOutcome, Failure> {
+    let policy = if force || args.replace_existing {
+        CollisionPolicy::Replace
+    } else if args.skip_existing {
+        CollisionPolicy::Skip
+    } else {
+        CollisionPolicy::Prompt
+    };
+    let mut candidate = catalog.clone();
+    let mut summary = ImportSummary::default();
+
+    for path in &args.paths {
+        let content = match fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(error) => {
+                warn!(
+                    "Could not import '{}': {error}; skipping file.",
+                    path.display()
+                );
+                continue;
+            }
+        };
+
+        for line in content.lines() {
+            let (name, command, global) = match parse_alias_line(line) {
+                ParsedLine::Alias {
+                    name,
+                    command,
+                    global,
+                } => (name, command, global),
+                ParsedLine::Unsupported => {
+                    summary.unsupported += 1;
+                    continue;
+                }
+                ParsedLine::Ignored => continue,
+            };
+
+            if let Some(existing) = candidate.aliases.get(&name) {
+                if is_identical(existing, &command, global) {
+                    summary.unchanged += 1;
+                    continue;
+                }
+
+                summary.collisions += 1;
+                let replace = match policy {
+                    CollisionPolicy::Replace => true,
+                    CollisionPolicy::Skip => false,
+                    CollisionPolicy::Prompt if args.dry_run => false,
+                    CollisionPolicy::Prompt => {
+                        prompt_replace_imported_alias(interaction_mode, &name)
+                    }
+                };
+                if !replace {
+                    if !args.dry_run || matches!(policy, CollisionPolicy::Skip) {
+                        summary.skipped_collisions += 1;
+                    }
+                    continue;
+                }
+                summary.replaced += 1;
+            } else {
+                summary.imported += 1;
+            }
+
+            let mut alias = Alias::new(command, true, global);
+            alias.tags.extend(args.tag.iter().cloned());
+            alias.refresh_representation();
+            candidate.aliases.insert(name, alias);
+        }
+    }
+
+    let changed = summary.imported + summary.replaced > 0;
+    if changed && !args.dry_run {
+        *catalog = candidate;
+    }
+    let outcome = if changed && !args.dry_run {
+        Outcome::CatalogChanged
+    } else {
+        Outcome::NoChanges
+    };
+    Ok(CommandOutcome::with_message(
+        outcome,
+        format_summary(&summary, args.dry_run, policy),
+    ))
+}
+
+fn format_summary(summary: &ImportSummary, dry_run: bool, policy: CollisionPolicy) -> String {
+    let mut parts = if dry_run {
+        vec![format!(
+            "Dry run: {} aliases would be imported",
+            summary.imported
+        )]
+    } else {
+        vec![format!("Imported {} aliases", summary.imported)]
+    };
+
+    if summary.collisions > 0 {
+        let collision_result = if dry_run {
+            match policy {
+                CollisionPolicy::Prompt => String::new(),
+                CollisionPolicy::Skip => " and would be skipped".into(),
+                CollisionPolicy::Replace => " and would be replaced".into(),
+            }
+        } else {
+            format!(
+                "; {} replaced and {} skipped",
+                summary.replaced, summary.skipped_collisions
+            )
+        };
+        parts.push(format!(
+            "{} collisions found{collision_result}",
+            summary.collisions
+        ));
+    }
+    if summary.unchanged > 0 {
+        parts.push(format!("{} aliases unchanged", summary.unchanged));
+    }
+    if summary.unsupported > 0 {
+        parts.push(format!("{} unsupported lines skipped", summary.unsupported));
+    }
+    format!("{}.", parts.join("; "))
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod doctor;
 pub(crate) mod edit;
 pub(crate) mod enable;
 pub(crate) mod file_path;
+pub(crate) mod import;
 pub(crate) mod init;
 pub(crate) mod list;
 pub(crate) mod remove;

--- a/src/catalog/types.rs
+++ b/src/catalog/types.rs
@@ -33,7 +33,7 @@ impl Alias {
 }
 
 /// Overall catalog containing aliases in deterministic name order.
-#[derive(PartialEq, Eq, Debug, Default)]
+#[derive(PartialEq, Eq, Debug, Default, Clone)]
 pub struct AliasCatalog {
     pub aliases: BTreeMap<String, Alias>,
 }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,0 +1,24 @@
+use std::path::PathBuf;
+
+use clap::Args;
+
+use super::validate_tag;
+
+#[derive(Args)]
+pub struct ImportCommand {
+    /// Bash or Zsh files containing alias declarations
+    #[arg(required = true)]
+    pub paths: Vec<PathBuf>,
+    /// Add a tag to every imported alias; repeat to add multiple tags
+    #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
+    pub tag: Vec<String>,
+    /// Report what would happen without changing the catalog
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Keep catalog entries when imported aliases have the same names
+    #[arg(long, conflicts_with = "replace_existing")]
+    pub skip_existing: bool,
+    /// Replace catalog entries when imported aliases have the same names
+    #[arg(long, conflicts_with = "skip_existing")]
+    pub replace_existing: bool,
+}

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -34,6 +34,19 @@ pub fn prompt_overwrite_existing_alias(mode: InteractionMode, alias: &str) -> bo
 }
 
 #[cfg_attr(coverage_nightly, coverage(off))]
+pub fn prompt_replace_imported_alias(mode: InteractionMode, alias: &str) -> bool {
+    non_interactive_answer(mode, "replace an existing alias during import").unwrap_or_else(|| {
+        Confirm::new()
+            .with_prompt(format!(
+                "Alias \"{alias}\" already exists. Replace it with the imported alias?"
+            ))
+            .default(false)
+            .interact()
+            .unwrap()
+    })
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub fn prompt_use_non_existing_catalog_file(mode: InteractionMode, path: &str) -> bool {
     non_interactive_answer(mode, &format!("use missing catalog path '{path}'")).unwrap_or_else(
         || {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod disable;
 pub(crate) mod doctor;
 pub(crate) mod edit;
 pub(crate) mod enable;
+pub(crate) mod import;
 pub(crate) mod init;
 pub(crate) mod interaction;
 pub(crate) mod list;
@@ -19,6 +20,7 @@ use disable::DisableCommand;
 use doctor::DoctorCommand;
 use edit::EditCommand;
 use enable::EnableCommand;
+use import::ImportCommand;
 use init::InitCommand;
 use list::ListCommand;
 use remove::RemoveCommand;
@@ -71,6 +73,12 @@ impl Cli {
                 "--force cannot be used with --if-changed",
             ));
         }
+        if self.force && matches!(&self.command, Commands::Import(cmd) if cmd.skip_existing) {
+            return Err(Self::command().error(
+                ErrorKind::ArgumentConflict,
+                "--force cannot be used with --skip-existing",
+            ));
+        }
         if matches!(&self.command, Commands::Edit(cmd) if !cmd.has_changes()) {
             return Err(Self::command().error(
                 ErrorKind::MissingRequiredArgument,
@@ -107,6 +115,9 @@ pub enum Commands {
     /// Edit an alias command or metadata
     #[command(visible_alias = "ed")]
     Edit(EditCommand),
+    /// Import aliases from Bash or Zsh files
+    #[command(visible_alias = "im")]
+    Import(ImportCommand),
     /// Synchronize aliases with the catalog
     Sync(SyncCommand),
     #[command(hide = true)]
@@ -118,6 +129,8 @@ pub enum Commands {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     #[test]
@@ -174,5 +187,45 @@ mod tests {
         ] {
             assert!(Cli::try_parse_from(args).is_err(), "{args:?}");
         }
+    }
+
+    #[test]
+    fn import_parses_multiple_paths_tags_and_collision_policy() {
+        let cli = Cli::try_parse_from([
+            "aliasmgr",
+            "import",
+            ".bashrc",
+            ".zshrc",
+            "--tag",
+            "shell",
+            "--dry-run",
+            "--replace-existing",
+        ])
+        .unwrap();
+        assert!(
+            matches!(cli.command, Commands::Import(ImportCommand { paths, tag, dry_run: true, replace_existing: true, .. }) if paths == [PathBuf::from(".bashrc"), PathBuf::from(".zshrc")] && tag == ["shell"])
+        );
+    }
+
+    #[test]
+    fn import_rejects_conflicting_collision_policies() {
+        assert!(
+            Cli::try_parse_from([
+                "aliasmgr",
+                "import",
+                ".zshrc",
+                "--skip-existing",
+                "--replace-existing",
+            ])
+            .is_err()
+        );
+
+        let cli =
+            Cli::try_parse_from(["aliasmgr", "--force", "import", ".zshrc", "--skip-existing"])
+                .unwrap();
+        assert_eq!(
+            cli.validate_prompt_controls().unwrap_err().kind(),
+            ErrorKind::ArgumentConflict
+        );
     }
 }

--- a/src/core/import.rs
+++ b/src/core/import.rs
@@ -1,0 +1,216 @@
+//! Parse individual Bash and Zsh alias declarations.
+
+use crate::catalog::types::Alias;
+use crate::core::validation::is_valid_alias_name;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParsedLine {
+    Ignored,
+    Unsupported,
+    Alias {
+        name: String,
+        command: String,
+        global: bool,
+    },
+}
+
+pub fn parse_alias_line(line: &str) -> ParsedLine {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return ParsedLine::Ignored;
+    }
+
+    let Some(mut declaration) = line.strip_prefix("alias") else {
+        return ParsedLine::Unsupported;
+    };
+    if !declaration.starts_with(char::is_whitespace) {
+        return ParsedLine::Unsupported;
+    }
+    declaration = declaration.trim_start();
+
+    let global = if let Some(rest) = declaration.strip_prefix("-g") {
+        if !rest.starts_with(char::is_whitespace) {
+            return ParsedLine::Unsupported;
+        }
+        declaration = rest.trim_start();
+        true
+    } else {
+        false
+    };
+
+    let Some((name, value)) = declaration.split_once('=') else {
+        return ParsedLine::Unsupported;
+    };
+    if !is_valid_alias_name(name) {
+        return ParsedLine::Unsupported;
+    }
+
+    let Some((command, remainder)) = parse_shell_word(value) else {
+        return ParsedLine::Unsupported;
+    };
+    let remainder = remainder.trim_start();
+    if !remainder.is_empty() && !remainder.starts_with('#') {
+        return ParsedLine::Unsupported;
+    }
+
+    ParsedLine::Alias {
+        name: name.into(),
+        command,
+        global,
+    }
+}
+
+pub fn is_identical(existing: &Alias, command: &str, global: bool) -> bool {
+    existing.command == command && existing.global == global
+}
+
+fn parse_shell_word(input: &str) -> Option<(String, &str)> {
+    #[derive(Clone, Copy)]
+    enum Quote {
+        Single,
+        Double,
+    }
+
+    let mut command = String::new();
+    let mut chars = input.char_indices().peekable();
+    let mut quote = None;
+    let mut consumed = 0;
+    let mut saw_content = false;
+
+    while let Some((index, character)) = chars.next() {
+        consumed = index + character.len_utf8();
+        match quote {
+            Some(Quote::Single) => {
+                if character == '\'' {
+                    quote = None;
+                } else {
+                    command.push(character);
+                }
+                saw_content = true;
+            }
+            Some(Quote::Double) => {
+                if character == '"' {
+                    quote = None;
+                    saw_content = true;
+                } else if matches!(character, '$' | '`') {
+                    return None;
+                } else if character == '\\' {
+                    let (_, escaped) = chars.next()?;
+                    consumed += escaped.len_utf8();
+                    command.push(escaped);
+                    saw_content = true;
+                } else {
+                    command.push(character);
+                    saw_content = true;
+                }
+            }
+            None => match character {
+                '\'' | '"' => {
+                    quote = Some(if character == '\'' {
+                        Quote::Single
+                    } else {
+                        Quote::Double
+                    });
+                    saw_content = true;
+                }
+                '\\' => {
+                    let (_, escaped) = chars.next()?;
+                    consumed += escaped.len_utf8();
+                    command.push(escaped);
+                    saw_content = true;
+                }
+                character if character.is_whitespace() => {
+                    consumed = index;
+                    break;
+                }
+                '$' | '`' | '*' | '?' | '[' | '{' | '~' | ';' | '&' | '|' | '<' | '>' | '('
+                | ')' => return None,
+                _ => {
+                    command.push(character);
+                    saw_content = true;
+                }
+            },
+        }
+    }
+
+    if quote.is_some() || !saw_content {
+        return None;
+    }
+    Some((command, &input[consumed..]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bash_and_zsh_aliases() {
+        assert_eq!(
+            parse_alias_line("alias ll='ls -la'"),
+            ParsedLine::Alias {
+                name: "ll".into(),
+                command: "ls -la".into(),
+                global: false,
+            }
+        );
+        assert_eq!(
+            parse_alias_line("  alias -g G=\"| grep\" # zsh global"),
+            ParsedLine::Alias {
+                name: "G".into(),
+                command: "| grep".into(),
+                global: true,
+            }
+        );
+        assert_eq!(
+            parse_alias_line(r"alias escaped=ls\ -la"),
+            ParsedLine::Alias {
+                name: "escaped".into(),
+                command: "ls -la".into(),
+                global: false,
+            }
+        );
+        assert_eq!(
+            parse_alias_line(r#"alias quoted="echo \"hello\"""#),
+            ParsedLine::Alias {
+                name: "quoted".into(),
+                command: "echo \"hello\"".into(),
+                global: false,
+            }
+        );
+    }
+
+    #[test]
+    fn ignores_blank_and_comment_lines() {
+        assert_eq!(parse_alias_line(""), ParsedLine::Ignored);
+        assert_eq!(parse_alias_line("  # aliases"), ParsedLine::Ignored);
+    }
+
+    #[test]
+    fn skips_unsupported_constructs() {
+        for line in [
+            "function ll() { ls -la; }",
+            "alias ll='unterminated",
+            "alias two='echo two'; echo extra",
+            "alias a='one' b='two'",
+            "alias invalid name='cmd'",
+            "alias variable=\"echo $HOME\"",
+            "alias command='safe'$(computed)",
+            "alias glob=*.rs",
+            "aliasfoo=bar",
+            "alias -global value=bar",
+            "alias ll",
+        ] {
+            assert_eq!(parse_alias_line(line), ParsedLine::Unsupported, "{line}");
+        }
+    }
+
+    #[test]
+    fn identical_aliases_ignore_catalog_only_metadata() {
+        let mut alias = Alias::new("ls -la".into(), false, false);
+        alias.description = Some("Files".into());
+        alias.tags.insert("shell".into());
+        assert!(is_identical(&alias, "ls -la", false));
+        assert!(!is_identical(&alias, "ls", false));
+        assert!(!is_identical(&alias, "ls -la", true));
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod conflict;
 pub(crate) mod disable;
 pub(crate) mod edit;
 pub(crate) mod enable;
+pub(crate) mod import;
 pub(crate) mod list;
 pub(crate) mod remove;
 pub(crate) mod rename;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use app::doctor::handle_doctor;
 use app::edit::handle_edit;
 use app::enable::handle_enable;
 use app::file_path::determine_catalog_path;
+use app::import::handle_import;
 use app::init::handle_init;
 use app::list::handle_list;
 use app::remove::handle_remove;
@@ -114,6 +115,7 @@ fn main() {
         }
         Commands::Rename(cmd) => handle_rename(&mut catalog, cmd),
         Commands::Edit(cmd) => handle_edit(&mut catalog, cmd, &shell).map(CommandOutcome::from),
+        Commands::Import(cmd) => handle_import(&mut catalog, cmd, interaction_mode, cli.force),
         Commands::Enable(cmd) => handle_enable(&mut catalog, cmd),
         Commands::Disable(cmd) => handle_disable(&mut catalog, cmd),
         Commands::Doctor(_) => handle_doctor(&catalog, &shell, quiet).map(CommandOutcome::from),

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1,0 +1,212 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_aliasmgr(catalog: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(args)
+        .env("ALIASMGR_CATALOG_PATH", catalog)
+        .env("ALIASMGR_SHELL", "zsh")
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn imports_bash_and_zsh_aliases_from_multiple_files() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let bash = directory.path().join("bashrc");
+    let zsh = directory.path().join("zshrc");
+    fs::write(&catalog, "existing = \"echo existing\"\n").unwrap();
+    fs::write(
+        &bash,
+        "# shell aliases\nalias ll='ls -la'\nfunction ignored() { echo no; }\n",
+    )
+    .unwrap();
+    fs::write(&zsh, "alias -g G='| grep'\nalias gs=git\\ status\n").unwrap();
+
+    let output = run_aliasmgr(
+        &catalog,
+        &[
+            "import",
+            bash.to_str().unwrap(),
+            zsh.to_str().unwrap(),
+            "--tag",
+            "shell",
+        ],
+    );
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Imported 3 aliases; 1 unsupported lines skipped."
+    );
+    let content = fs::read_to_string(&catalog).unwrap();
+    assert!(content.contains("existing = \"echo existing\""));
+    assert!(content.contains("ll = { command = \"ls -la\""));
+    assert!(content.contains("G = { command = \"| grep\", enabled = true, global = true"));
+    assert!(content.contains("gs = { command = \"git status\""));
+    assert_eq!(content.matches("tags = [\"shell\"]").count(), 3);
+}
+
+#[test]
+fn collision_policies_preserve_identical_aliases_and_replace_differences() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let source = directory.path().join("aliases.zsh");
+    let original = concat!(
+        "ll = { command = \"ls -la\", enabled = false, global = false, description = \"Files\", tags = [\"existing\"] }\n",
+        "gs = \"git status\"\n",
+    );
+    fs::write(&catalog, original).unwrap();
+    fs::write(
+        &source,
+        "alias ll='ls -la'\nalias gs='git status --short'\n",
+    )
+    .unwrap();
+
+    let skipped = run_aliasmgr(
+        &catalog,
+        &["import", source.to_str().unwrap(), "--skip-existing"],
+    );
+    assert!(skipped.status.success(), "{skipped:?}");
+    assert!(
+        String::from_utf8_lossy(&skipped.stdout)
+            .contains("1 collisions found; 0 replaced and 1 skipped")
+    );
+    assert!(String::from_utf8_lossy(&skipped.stdout).contains("1 aliases unchanged"));
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+
+    let replaced = run_aliasmgr(
+        &catalog,
+        &["import", source.to_str().unwrap(), "--replace-existing"],
+    );
+    assert!(replaced.status.success(), "{replaced:?}");
+    let content = fs::read_to_string(&catalog).unwrap();
+    assert!(content.contains("gs = \"git status --short\""));
+    assert!(content.contains("description = \"Files\""));
+    assert!(content.contains("tags = [\"existing\"]"));
+    assert!(content.contains("enabled = false"));
+}
+
+#[test]
+fn force_aliases_replace_and_no_input_requires_a_policy() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let source = directory.path().join("aliases");
+    fs::write(&catalog, "ll = \"ls\"\n").unwrap();
+    fs::write(&source, "alias ll='ls -la'\n").unwrap();
+
+    let refused = run_aliasmgr(
+        &catalog,
+        &["import", source.to_str().unwrap(), "--no-input"],
+    );
+    assert_eq!(refused.status.code(), Some(2));
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), "ll = \"ls\"\n");
+
+    let replaced = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "--force"]);
+    assert!(replaced.status.success(), "{replaced:?}");
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), "ll = \"ls -la\"\n");
+}
+
+#[test]
+fn dry_run_reports_without_prompting_or_writing() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let source = directory.path().join("aliases");
+    let original = "ll = \"ls\"\n";
+    fs::write(&catalog, original).unwrap();
+    fs::write(&source, "alias ll='ls -la'\nalias gs='git status'\n").unwrap();
+
+    let output = run_aliasmgr(&catalog, &["import", source.to_str().unwrap(), "--dry-run"]);
+    assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Dry run: 1 aliases would be imported"));
+    assert!(stdout.contains("1 collisions found"));
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+
+    let skipped = run_aliasmgr(
+        &catalog,
+        &[
+            "import",
+            source.to_str().unwrap(),
+            "--dry-run",
+            "--skip-existing",
+        ],
+    );
+    assert!(
+        String::from_utf8_lossy(&skipped.stdout)
+            .contains("1 collisions found and would be skipped")
+    );
+
+    let replaced = run_aliasmgr(
+        &catalog,
+        &[
+            "import",
+            source.to_str().unwrap(),
+            "--dry-run",
+            "--replace-existing",
+        ],
+    );
+    assert!(
+        String::from_utf8_lossy(&replaced.stdout)
+            .contains("1 collisions found and would be replaced")
+    );
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+}
+
+#[test]
+fn unreadable_sources_warn_and_do_not_prevent_other_imports() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let missing = directory.path().join("missing");
+    let source = directory.path().join("aliases");
+    fs::write(&catalog, "").unwrap();
+    fs::write(&source, "alias ll='ls -la'\n").unwrap();
+
+    let output = run_aliasmgr(
+        &catalog,
+        &[
+            "import",
+            missing.to_str().unwrap(),
+            source.to_str().unwrap(),
+        ],
+    );
+    assert!(output.status.success(), "{output:?}");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("skipping file"));
+    assert!(
+        fs::read_to_string(&catalog)
+            .unwrap()
+            .contains("ll = \"ls -la\"")
+    );
+}
+
+#[test]
+fn all_unreadable_sources_still_succeed_without_changes() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original = "ll = \"ls -la\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    let output = run_aliasmgr(
+        &catalog,
+        &[
+            "import",
+            directory.path().join("missing-one").to_str().unwrap(),
+            directory.path().join("missing-two").to_str().unwrap(),
+        ],
+    );
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Imported 0 aliases."
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr)
+            .matches("skipping file")
+            .count(),
+        2
+    );
+    assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+}


### PR DESCRIPTION
## Summary

- add an import command for ordinary Bash and Zsh alias declaration files
- merge imported aliases into the current catalog with tags, Zsh global aliases, dry-run reporting, and explicit collision policies
- silently skip unsupported shell constructs while warning and continuing for unreadable input paths

## Acceptance criteria

- plain aliases from one or more paths are added without replacing the existing catalog
- differing name collisions prompt with skip as the default; --skip-existing keeps them, while --replace-existing and --force replace them
- unsupported or computed shell constructs are safely skipped and included in the aggregate summary
- imported aliases persist through the existing deterministic TOML save/load path

## Validation

- cargo build
- cargo test
- cargo clippy
- cargo fmt --check
- cargo +nightly llvm-cov --all-features --workspace --lcov --output-path /private/tmp/aliasmgr-issue4-lcov.info

Closes #4
