### PR TITLE
Refresh alias TOML representation when saving

### DIFF
--- a/src/app/add.rs
+++ b/src/app/add.rs
@@ -29,7 +29,6 @@ pub fn handle_add(
     let mut alias = Alias::new(args.command, !args.disabled, args.global);
     alias.description = args.description;
     alias.tags.extend(args.tag);
-    alias.refresh_representation();
 
     let outcome = if catalog.aliases.contains_key(&args.name) {
         if prompt_overwrite_existing_alias(interaction_mode, &args.name) {

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -40,7 +40,6 @@ pub fn handle_edit(
     if cmd.no_global {
         alias.global = false;
     }
-    alias.refresh_representation();
     let outcome = edit_alias(catalog, &cmd.name, &alias)?;
     if outcome == Outcome::CatalogChanged {
         for warning in conflict_warnings([cmd.name.as_str()], shell)

--- a/src/app/import.rs
+++ b/src/app/import.rs
@@ -96,7 +96,6 @@ pub fn handle_import(
 
             let mut alias = Alias::new(command, true, global);
             alias.tags.extend(args.tag.iter().cloned());
-            alias.refresh_representation();
             candidate.aliases.insert(name, alias);
         }
     }

--- a/src/catalog/io.rs
+++ b/src/catalog/io.rs
@@ -41,12 +41,7 @@ pub fn load_catalog(path: &PathBuf) -> Result<AliasCatalog> {
 }
 
 fn build_alias_item(alias: &Alias) -> Item {
-    if !alias.detailed
-        && alias.enabled
-        && !alias.global
-        && alias.description.is_none()
-        && alias.tags.is_empty()
-    {
+    if !alias.detailed {
         return Item::Value(alias.command.clone().into());
     }
 
@@ -68,15 +63,16 @@ fn build_alias_item(alias: &Alias) -> Item {
     Item::Value(inline.into())
 }
 
-fn build_toml_document(catalog: &AliasCatalog) -> DocumentMut {
+fn build_toml_document(catalog: &mut AliasCatalog) -> DocumentMut {
     let mut document = DocumentMut::new();
-    for (name, alias) in &catalog.aliases {
+    for (name, alias) in &mut catalog.aliases {
+        alias.refresh_representation();
         document[name] = build_alias_item(alias);
     }
     document
 }
 
-pub fn save_catalog(catalog: &AliasCatalog, path: &PathBuf) -> Result<()> {
+pub fn save_catalog(catalog: &mut AliasCatalog, path: &PathBuf) -> Result<()> {
     let content = build_toml_document(catalog).to_string();
     if !path.exists() {
         warn!("alias catalog file {:?} does not exist, creating it", path);
@@ -104,12 +100,69 @@ mod tests {
         alias
             .tags
             .extend(["rust".into(), "dev".into(), "rust".into()]);
-        alias.refresh_representation();
         catalog.aliases.insert("test".into(), alias);
 
-        save_catalog(&catalog, &path).unwrap();
+        save_catalog(&mut catalog, &path).unwrap();
         let saved = fs::read_to_string(&path).unwrap();
         assert!(saved.contains("tags = [\"dev\", \"rust\"]"));
+        assert_eq!(load_catalog(&path).unwrap(), catalog);
+    }
+
+    #[test]
+    fn saving_refreshes_each_alias_representation() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("aliases.toml");
+        let mut catalog = AliasCatalog::new();
+
+        let mut disabled = Alias::new("disabled".into(), true, false);
+        disabled.enabled = false;
+        catalog.aliases.insert("disabled".into(), disabled);
+
+        let mut global = Alias::new("global".into(), true, false);
+        global.global = true;
+        catalog.aliases.insert("global".into(), global);
+
+        let mut described = Alias::new("described".into(), true, false);
+        described.description = Some("Description".into());
+        catalog.aliases.insert("described".into(), described);
+
+        let mut tagged = Alias::new("tagged".into(), true, false);
+        tagged.tags.insert("tag".into());
+        catalog.aliases.insert("tagged".into(), tagged);
+
+        assert!(catalog.aliases.values().all(|alias| !alias.detailed));
+        save_catalog(&mut catalog, &path).unwrap();
+
+        assert!(catalog.aliases.values().all(|alias| alias.detailed));
+        let saved = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            saved,
+            concat!(
+                "described = { command = \"described\", enabled = true, global = false, description = \"Description\" }\n",
+                "disabled = { command = \"disabled\", enabled = false, global = false }\n",
+                "global = { command = \"global\", enabled = true, global = true }\n",
+                "tagged = { command = \"tagged\", enabled = true, global = false, tags = [\"tag\"] }\n",
+            )
+        );
+        assert_eq!(load_catalog(&path).unwrap(), catalog);
+    }
+
+    #[test]
+    fn saving_normalizes_unneeded_detailed_representation() {
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("aliases.toml");
+        fs::write(
+            &path,
+            "ll = { command = \"ls -la\", enabled = true, global = false }\n",
+        )
+        .unwrap();
+        let mut catalog = load_catalog(&path).unwrap();
+        assert!(catalog.aliases["ll"].detailed);
+
+        save_catalog(&mut catalog, &path).unwrap();
+
+        assert!(!catalog.aliases["ll"].detailed);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "ll = \"ls -la\"\n");
         assert_eq!(load_catalog(&path).unwrap(), catalog);
     }
 
@@ -122,9 +175,12 @@ mod tests {
             "ll = \"ls -la\"\ntest = { command = \"cargo test\", tags = [\"dev\"] }\n",
         )
         .unwrap();
-        let catalog = load_catalog(&path).unwrap();
+        let mut catalog = load_catalog(&path).unwrap();
         assert!(!catalog.aliases["ll"].detailed);
         assert!(catalog.aliases["test"].tags.contains("dev"));
+
+        save_catalog(&mut catalog, &path).unwrap();
+        assert_eq!(load_catalog(&path).unwrap(), catalog);
     }
 
     #[test]

--- a/src/catalog/io.rs
+++ b/src/catalog/io.rs
@@ -40,7 +40,8 @@ pub fn load_catalog(path: &PathBuf) -> Result<AliasCatalog> {
     Ok(convert_spec_to_catalog(spec))
 }
 
-fn build_alias_item(alias: &Alias) -> Item {
+fn build_alias_item(alias: &mut Alias) -> Item {
+    alias.refresh_representation();
     if !alias.detailed {
         return Item::Value(alias.command.clone().into());
     }
@@ -66,7 +67,6 @@ fn build_alias_item(alias: &Alias) -> Item {
 fn build_toml_document(catalog: &mut AliasCatalog) -> DocumentMut {
     let mut document = DocumentMut::new();
     for (name, alias) in &mut catalog.aliases {
-        alias.refresh_representation();
         document[name] = build_alias_item(alias);
     }
     document

--- a/src/core/remove.rs
+++ b/src/core/remove.rs
@@ -33,7 +33,6 @@ pub fn remove_tag(catalog: &mut AliasCatalog, tag: &str) -> Result<(Outcome, usi
     let mut changed = 0;
     for alias in catalog.aliases.values_mut() {
         if alias.tags.remove(tag) {
-            alias.refresh_representation();
             changed += 1;
         }
     }

--- a/src/core/rename.rs
+++ b/src/core/rename.rs
@@ -37,7 +37,6 @@ pub fn rename_tag(
     for alias in catalog.aliases.values_mut() {
         if alias.tags.remove(old) {
             alias.tags.insert(new.into());
-            alias.refresh_representation();
             changed += 1;
         }
     }

--- a/src/core/status.rs
+++ b/src/core/status.rs
@@ -25,7 +25,6 @@ pub fn set_aliases(
             .expect("selected alias exists");
         if alias.enabled != enabled {
             alias.enabled = enabled;
-            alias.refresh_representation();
             changed += 1;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,8 @@ fn main() {
             match outcome {
                 Outcome::NoChanges => debug!("No changes made to catalog or shell."),
                 Outcome::CatalogChanged => {
-                    if save_catalog(&catalog, &resolve_catalog_path(catalog_path.as_ref())).is_err()
+                    if save_catalog(&mut catalog, &resolve_catalog_path(catalog_path.as_ref()))
+                        .is_err()
                     {
                         eprintln!("Failed to save updated catalog.");
                         return;


### PR DESCRIPTION
## Summary

- refresh each alias representation at the catalog persistence boundary immediately before TOML serialization
- remove representation bookkeeping from add, edit, import, status, tag removal, and tag rename mutation paths
- normalize eligible detailed entries to short form while preserving detailed-required fields, deterministic ordering, and round-trip data

## Validation

- `cargo build --verbose`
- `cargo test --verbose`
- `cargo clippy`
- `cargo fmt --check`
- `git diff --check`

## Acceptance criteria

Focused catalog I/O regressions cover stale mutation state, every detailed-form trigger, detailed-to-short normalization, mixed-form input, deterministic output order, and save/load round trips.

Closes #39