### PR TITLE
Bold list table headers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ disabled = "✘"
 global = "⦾"
 
 [styles]
+header = { bold = true }
 enabled = { foreground = "green", bold = true }
 disabled = { foreground = "red", bold = true }
 global = { foreground = "blue", bold = true }
@@ -70,6 +71,8 @@ status = "auto"
 ```
 
 `list.columns` is ordered. Valid names are `status`, `name`, `command`, `global`, `tags`, and `description`. With the default `status = "auto"`, the Status column is hidden when listing only enabled or disabled aliases and shown by `list --all`. Use `always` or `never` to override that behavior. An explicit `list --columns name,command,tags` is exhaustive and overrides the status policy for that command. The human-readable Global column is hidden under Bash even when configured or explicitly requested; JSON output still includes `global`. Interactive tables truncate wide cells with an ellipsis to fit the terminal; selected columns are never dropped.
+
+Table headers are bold by default when styling is enabled. Set `styles.header.bold = false` to use plain headers.
 
 `auto` color applies only to terminal output and respects `NO_COLOR`. The global `--color <auto|always|never>` option overrides the configured mode. Invalid known settings fail clearly; unknown settings warn and are ignored.
 

--- a/src/app/list.rs
+++ b/src/app/list.rs
@@ -1,6 +1,7 @@
 use std::io::IsTerminal;
 
 use globset::Glob;
+use owo_colors::OwoColorize;
 use serde::Serialize;
 use terminal_size::{Width, terminal_size};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
@@ -212,28 +213,21 @@ fn format_human(
         .collect::<Vec<_>>();
     let widths = column_widths(columns, &raw_rows, terminal_width);
 
-    let render_plain_row = |cells: Vec<String>| {
-        cells
-            .into_iter()
-            .enumerate()
-            .map(|(index, cell)| {
-                let value = truncate(&cell, widths[index]);
-                let padding = widths[index].saturating_sub(UnicodeWidthStr::width(value.as_str()));
-                value + &" ".repeat(padding)
-            })
-            .collect::<Vec<_>>()
-            .join("  ")
-            .trim_end()
-            .to_owned()
-            + "\n"
-    };
-
-    let mut output = render_plain_row(
-        columns
-            .iter()
-            .map(|column| header(*column).to_owned())
-            .collect(),
-    );
+    let header_cells = columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            let value = truncate(header(*column), widths[index]);
+            let padding = widths[index].saturating_sub(UnicodeWidthStr::width(value.as_str()));
+            let value = if config.styles.header.bold && colors_enabled {
+                value.bold().to_string()
+            } else {
+                value
+            };
+            value + &" ".repeat(padding)
+        })
+        .collect::<Vec<_>>();
+    let mut output = header_cells.join("  ").trim_end().to_owned() + "\n";
     for ((_, alias), raw_row) in aliases.iter().zip(raw_rows) {
         let cells = raw_row
             .into_iter()
@@ -380,6 +374,40 @@ mod tests {
         )
         .unwrap();
         assert!(output.lines().next().unwrap().contains("Global"));
+    }
+
+    #[test]
+    fn table_headers_are_bold_by_default_and_configurable() {
+        let output = format_list_with_width(
+            &catalog(),
+            &command(OutputFormat::Human),
+            &ShellType::Bash,
+            &UserConfig::default(),
+            true,
+            None,
+        )
+        .unwrap();
+        assert!(
+            output
+                .lines()
+                .next()
+                .unwrap()
+                .contains("\u{1b}[1mName\u{1b}[0m")
+        );
+
+        let mut config = UserConfig::default();
+        config.styles.header.bold = false;
+        let output = format_list_with_width(
+            &catalog(),
+            &command(OutputFormat::Human),
+            &ShellType::Bash,
+            &config,
+            true,
+            None,
+        )
+        .unwrap();
+        assert!(output.starts_with("Name  Command"));
+        assert!(!output.lines().next().unwrap().contains("\u{1b}["));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,7 +83,13 @@ impl StateStyle {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HeaderStyle {
+    pub bold: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StyleConfig {
+    pub header: HeaderStyle,
     pub enabled: StateStyle,
     pub disabled: StateStyle,
     pub global: StateStyle,
@@ -116,6 +122,7 @@ impl Default for ListConfig {
 impl Default for StyleConfig {
     fn default() -> Self {
         Self {
+            header: HeaderStyle { bold: true },
             enabled: StateStyle {
                 foreground: "green".into(),
                 bold: true,
@@ -187,9 +194,18 @@ struct RawSymbolConfig {
 #[derive(Default, Deserialize)]
 #[serde(default)]
 struct RawStyleConfig {
+    header: Option<RawHeaderStyle>,
     enabled: Option<RawStateStyle>,
     disabled: Option<RawStateStyle>,
     global: Option<RawStateStyle>,
+    #[serde(flatten)]
+    unknown: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct RawHeaderStyle {
+    bold: Option<bool>,
     #[serde(flatten)]
     unknown: BTreeMap<String, toml::Value>,
 }
@@ -273,6 +289,12 @@ fn parse_config_with_warnings(content: &str) -> Result<LoadedConfig> {
     ] {
         apply_style(name, target, style, &mut warnings)?;
     }
+    if let Some(header) = raw.styles.header {
+        collect_unknown_warnings(Some("styles.header"), &header.unknown, &mut warnings);
+        if let Some(bold) = header.bold {
+            config.styles.header.bold = bold;
+        }
+    }
     if let Some(columns) = raw.list.columns {
         if columns.is_empty() {
             bail!("'list.columns' must contain at least one column");
@@ -347,6 +369,7 @@ mod tests {
         assert_eq!(config.symbols.global, "⦾");
         assert_eq!(config.styles.enabled.foreground, "green");
         assert!(config.styles.enabled.bold);
+        assert!(config.styles.header.bold);
         assert_eq!(config.list.columns, ListColumn::DEFAULTS);
         assert_eq!(config.list.status, StatusColumnMode::Auto);
     }
@@ -360,6 +383,8 @@ mod tests {
             [symbols]
             enabled = "+"
             disabled = "-"
+            [styles.header]
+            bold = false
             [styles.disabled]
             foreground = "#ff00aa"
             bold = false
@@ -372,6 +397,7 @@ mod tests {
         assert_eq!(config.symbols.disabled, "-");
         assert_eq!(config.styles.disabled.foreground, "#ff00aa");
         assert!(!config.styles.disabled.bold);
+        assert!(!config.styles.header.bold);
     }
 
     #[test]
@@ -411,6 +437,7 @@ mod tests {
         assert!(parse_config("[color]\nmode = \"sometimes\"\n").is_err());
         assert!(parse_config("[styles.enabled]\nforeground = \"not-a-color\"\n").is_err());
         assert!(parse_config("[styles.enabled]\nbold = \"yes\"\n").is_err());
+        assert!(parse_config("[styles.header]\nbold = \"yes\"\n").is_err());
     }
 
     #[test]

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -28,6 +28,8 @@ fn explicit_configuration_controls_symbols_and_styles() {
         [list]
         columns = ["status", "name"]
         status = "always"
+        [styles.header]
+        bold = false
         [styles.enabled]
         foreground = "#ff00aa"
         bold = false


### PR DESCRIPTION
## Summary

- render human-readable list table headers in bold by default when styling is enabled
- add `styles.header.bold` configuration with a default of `true`
- preserve plain output when styling is disabled and document the override

## Why

List headers currently have no visual distinction from row content and no header-specific style configuration. This adds a focused setting while retaining the existing ANSI/color policy for redirected output and `--color never`.

## Validation

- `cargo test --verbose` (131 tests passed)
- `cargo clippy`
- `cargo fmt --check`
- `git diff --check`
