### PR TITLE
Add inline TUI alias editing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,11 +20,13 @@ dependencies = [
  "assert_matches",
  "clap",
  "cross-xdg",
+ "crossterm",
  "dialoguer",
  "env_logger",
  "globset",
  "log",
  "owo-colors",
+ "ratatui",
  "serde",
  "serde_json",
  "temp-env",
@@ -34,6 +36,12 @@ dependencies = [
  "toml_edit",
  "unicode-width",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -92,6 +100,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "assert_fs"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +127,12 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -131,6 +154,21 @@ checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "serde_core",
+]
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -186,6 +224,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +247,15 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -229,6 +290,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +382,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +426,21 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -329,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,15 +536,37 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
@@ -398,7 +591,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -406,6 +621,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -450,16 +674,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -477,10 +733,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -499,6 +800,39 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "parking_lot"
@@ -537,6 +871,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -590,6 +930,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.1",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +1034,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +1054,18 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -654,6 +1081,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -714,16 +1147,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "syn"
@@ -806,6 +1297,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +1376,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +1415,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1444,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,24 +13,26 @@ keywords = ["aliases", "shell", "cli", "manager"]
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.51", features = ["derive"] }
+crossterm = "0.29.0"
 cross-xdg = "2.0.0"
 dialoguer = "0.12.0"
 env_logger = "0.11.8"
 globset = "0.4.18"
 log = "0.4.28"
 owo-colors = "4.2.3"
+ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 toml = "0.9.8"
 toml_edit = "0.23.7"
 terminal_size = "0.4.3"
+tempfile = "3.23.0"
 unicode-width = "0.2.2"
 
 [dev-dependencies]
 assert_fs = "1.1.3"
 assert_matches = "1.5.0"
 temp-env = "0.3.6"
-tempfile = "3.23.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ CLI tool to manage shell aliases from a single, versionable TOML file, written i
 - Store aliases in `~/.config/aliasmgr/aliases.toml` (or a custom path).
 - Add optional descriptions and multiple searchable tags to aliases.
 - Add, edit, list, rename, enable, disable, and remove aliases or tag selections.
+- Edit one alias or the complete catalog in an inline mouse-and-keyboard terminal UI.
 - Render human-readable listings as configurable tables, or emit JSON for scripts.
 - Keep open terminals synchronized automatically before each prompt.
 - Track managed aliases per terminal so stale aliases can be removed without clearing unrelated shell aliases.
@@ -80,6 +81,8 @@ Table headers are bold by default when styling is enabled. Set `styles.header.bo
 
 - `aliasmgr add <name> <command> [-g|--global] [-t|--tag <tag>]... [-d|--description <text>] [--disabled]`
 - `aliasmgr edit <name> [command] [-a|--add-tag <tag>]... [-r|--remove-tag <tag>]... [-d|--description <text> | --clear-description] [-g|--global | --no-global]`
+- `aliasmgr edit -i <name>`
+- `aliasmgr edit -i --all`
 - `aliasmgr import <path>... [-d|--dry-run] [-s|--skip-existing | -r|--replace-existing] [-t|--tag <tag>]...`
 - `aliasmgr list [pattern] [-t|--tag <tag>]... [-d|--disabled | --all] [-g|--global] [--columns <columns>] [-f|--format <human|json>]`
 - `aliasmgr remove <name>`
@@ -105,6 +108,27 @@ Table headers are bold by default when styling is enabled. Set `styles.header.bo
 - `aliasmgr doctor` (also available as `aliasmgr validate`)
 
 For more details, use `-h` or `--help`.
+
+### Interactive editing
+
+Use `edit -i <name>` to edit one alias or `edit -i --all` to manage the complete catalog. The interactive editor occupies an automatically sized region at the bottom of the current terminal instead of switching to a full-screen alternate buffer. On small terminals, the catalog list and edit form become separate compact views.
+
+The single-alias form can change the name, command, description, comma-separated tags, and enabled state. Under Zsh it also shows a global-alias toggle; Bash preserves existing global state without showing that control. Renaming or adding an alias with an existing name asks before replacing it.
+
+The full-catalog editor searches alias names, commands, descriptions, and tags and supports adding, deleting, renaming, and replacing aliases. Changes remain in memory until saved. Invalid names, empty commands, and invalid tags prevent saving; cancelling or discarding leaves the catalog unchanged.
+
+Keyboard controls:
+
+- `Tab` / `Shift-Tab`: move focus.
+- Arrow keys: navigate lists, text, and choices.
+- `Space`: toggle the focused enabled/global control.
+- `Enter`: activate the focused action or open the compact edit form.
+- `Ctrl-S`: validate and save.
+- `Esc`: go back or cancel the current dialog.
+- `q`: quit when a text field is not focused.
+- `?`: show in-app help.
+
+Mouse clicks select fields and actions; the scroll wheel navigates the alias list. Attempting to quit with unsaved changes offers Save, Discard, and Cancel. The global `--yes`, `--no`, and `--no-input` controls cannot be combined with interactive editing.
 
 Notes:
 

--- a/src/app/edit.rs
+++ b/src/app/edit.rs
@@ -6,6 +6,7 @@ use crate::core::conflict::conflict_warnings;
 use crate::core::edit::edit_alias;
 use crate::core::{Failure, Outcome};
 
+use super::edit_tui::{self, EditorMode, EditorResult};
 use super::shell::ShellType;
 
 pub fn handle_edit(
@@ -13,9 +14,23 @@ pub fn handle_edit(
     cmd: EditCommand,
     shell: &ShellType,
 ) -> Result<Outcome, Failure> {
+    if cmd.interactive {
+        let mode = if cmd.all {
+            EditorMode::All
+        } else {
+            EditorMode::Single
+        };
+        let result = edit_tui::run(catalog, cmd.name.as_deref(), mode, shell.clone())
+            .map_err(Failure::InteractiveEditor)?;
+        return Ok(apply_interactive_result(catalog, result, shell));
+    }
+    let name = cmd
+        .name
+        .as_deref()
+        .expect("validated non-interactive edit name");
     let mut alias = catalog
         .aliases
-        .get(&cmd.name)
+        .get(name)
         .cloned()
         .ok_or(Failure::AliasDoesNotExist)?;
     if let Some(command) = cmd.command {
@@ -40,10 +55,10 @@ pub fn handle_edit(
     if cmd.no_global {
         alias.global = false;
     }
-    let outcome = edit_alias(catalog, &cmd.name, &alias)?;
+    let outcome = edit_alias(catalog, name, &alias)?;
     if outcome == Outcome::CatalogChanged {
-        for warning in conflict_warnings([cmd.name.as_str()], shell)
-            .get(&cmd.name)
+        for warning in conflict_warnings([name], shell)
+            .get(name)
             .into_iter()
             .flatten()
         {
@@ -51,4 +66,71 @@ pub fn handle_edit(
         }
     }
     Ok(outcome)
+}
+
+fn apply_interactive_result(
+    catalog: &mut AliasCatalog,
+    result: EditorResult,
+    shell: &ShellType,
+) -> Outcome {
+    match result {
+        EditorResult::Continue => {
+            unreachable!("the interactive event loop cannot return Continue")
+        }
+        EditorResult::ExitNoChanges => Outcome::NoChanges,
+        EditorResult::Save(updated) => {
+            let changed_names = updated
+                .aliases
+                .iter()
+                .filter_map(|(name, alias)| {
+                    catalog
+                        .aliases
+                        .get(name)
+                        .is_none_or(|existing| {
+                            existing.command != alias.command
+                                || existing.enabled != alias.enabled
+                                || existing.global != alias.global
+                                || existing.description != alias.description
+                                || existing.tags != alias.tags
+                        })
+                        .then_some(name.as_str())
+                })
+                .collect::<Vec<_>>();
+            for warning in conflict_warnings(changed_names, shell).values().flatten() {
+                warn!("{warning}");
+            }
+            *catalog = updated;
+            Outcome::CatalogChanged
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::types::Alias;
+
+    #[test]
+    fn interactive_results_apply_only_saved_catalogs() {
+        let mut catalog = AliasCatalog::new();
+        catalog
+            .aliases
+            .insert("old".into(), Alias::new("old".into(), true, false));
+        assert_eq!(
+            apply_interactive_result(&mut catalog, EditorResult::ExitNoChanges, &ShellType::Bash),
+            Outcome::NoChanges
+        );
+        assert!(catalog.aliases.contains_key("old"));
+
+        let mut updated = AliasCatalog::new();
+        updated
+            .aliases
+            .insert("new".into(), Alias::new("new".into(), true, false));
+        assert_eq!(
+            apply_interactive_result(&mut catalog, EditorResult::Save(updated), &ShellType::Bash),
+            Outcome::CatalogChanged
+        );
+        assert!(catalog.aliases.contains_key("new"));
+        assert!(!catalog.aliases.contains_key("old"));
+    }
 }

--- a/src/app/edit_tui/mod.rs
+++ b/src/app/edit_tui/mod.rs
@@ -1,0 +1,1119 @@
+mod model;
+
+use std::io::{self, IsTerminal};
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::time::Duration;
+
+use crossterm::cursor::Show;
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
+    MouseButton, MouseEvent, MouseEventKind,
+};
+use crossterm::execute;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::{DefaultTerminal, Frame, TerminalOptions, Viewport};
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::shell::ShellType;
+use crate::catalog::types::AliasCatalog;
+
+pub use model::{EditorMode, EditorResult};
+use model::{EditorState, Focus, Modal, TextAction};
+
+const MIN_TERMINAL_ROWS: u16 = 10;
+const WIDE_LAYOUT_WIDTH: u16 = 80;
+const WIDE_LAYOUT_HEIGHT: u16 = 17;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MouseTarget {
+    Focus(Focus),
+    Alias(u64),
+    ModalChoice(usize),
+}
+
+#[derive(Default)]
+struct UiAreas(Vec<(Rect, MouseTarget)>);
+
+impl UiAreas {
+    fn add(&mut self, area: Rect, target: MouseTarget) {
+        self.0.push((area, target));
+    }
+    fn at(&self, column: u16, row: u16) -> Option<MouseTarget> {
+        self.0
+            .iter()
+            .rev()
+            .find(|(area, _)| {
+                column >= area.x
+                    && column < area.x + area.width
+                    && row >= area.y
+                    && row < area.y + area.height
+            })
+            .map(|(_, target)| *target)
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+pub fn run(
+    catalog: &AliasCatalog,
+    name: Option<&str>,
+    mode: EditorMode,
+    shell: ShellType,
+) -> Result<EditorResult, String> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err("interactive editing requires a terminal on stdin and stdout".to_owned());
+    }
+    let (_, rows) = crossterm::terminal::size()
+        .map_err(|error| format!("could not determine terminal size: {error}"))?;
+    let height = inline_height(rows).ok_or_else(|| {
+        format!(
+            "terminal is too short for interactive editing (need at least {MIN_TERMINAL_ROWS} rows)"
+        )
+    })?;
+    let mut state = match mode {
+        EditorMode::Single => {
+            EditorState::single(catalog, name.ok_or("an alias name is required")?, shell)?
+        }
+        EditorMode::All => EditorState::all(catalog, shell),
+    };
+    let options = TerminalOptions {
+        viewport: Viewport::Inline(height),
+    };
+    let mut terminal = match ratatui::try_init_with_options(options) {
+        Ok(terminal) => terminal,
+        Err(error) => {
+            ratatui::restore();
+            return Err(format!("could not initialize interactive editor: {error}"));
+        }
+    };
+    if let Err(error) = execute!(terminal.backend_mut(), EnableMouseCapture) {
+        ratatui::restore();
+        return Err(format!("could not enable mouse input: {error}"));
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| event_loop(&mut terminal, &mut state)));
+    let clear_result = terminal.clear();
+    let mouse_result = execute!(terminal.backend_mut(), DisableMouseCapture, Show);
+    let restore_result = ratatui::try_restore();
+    if let Err(payload) = result {
+        resume_unwind(payload);
+    }
+    clear_result.map_err(|error| format!("could not clear interactive editor: {error}"))?;
+    mouse_result.map_err(|error| format!("could not restore mouse input: {error}"))?;
+    restore_result.map_err(|error| format!("could not restore terminal: {error}"))?;
+    result.unwrap()
+}
+
+fn inline_height(rows: u16) -> Option<u16> {
+    if rows < MIN_TERMINAL_ROWS {
+        return None;
+    }
+    if rows < 15 {
+        Some(rows - 1)
+    } else {
+        Some(((rows * 3) / 5).clamp(10, 22).min(rows - 3))
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+fn event_loop(
+    terminal: &mut DefaultTerminal,
+    state: &mut EditorState,
+) -> Result<EditorResult, String> {
+    let mut areas = UiAreas::default();
+    loop {
+        terminal
+            .draw(|frame| {
+                areas = UiAreas::default();
+                render(frame, state, &mut areas);
+            })
+            .map_err(|error| format!("could not draw interactive editor: {error}"))?;
+        if !event::poll(Duration::from_millis(250))
+            .map_err(|error| format!("could not poll terminal input: {error}"))?
+        {
+            continue;
+        }
+        let result = match event::read()
+            .map_err(|error| format!("could not read terminal input: {error}"))?
+        {
+            Event::Key(key) if key.kind == event::KeyEventKind::Press => handle_key(state, key),
+            Event::Mouse(mouse) => handle_mouse(state, mouse, &areas),
+            Event::Resize(_, _) => EditorResult::Continue,
+            _ => EditorResult::Continue,
+        };
+        if result != EditorResult::Continue {
+            return Ok(result);
+        }
+    }
+}
+
+fn handle_key(state: &mut EditorState, key: KeyEvent) -> EditorResult {
+    if state.modal.is_some() {
+        return match key.code {
+            KeyCode::Esc => {
+                state.dismiss_modal();
+                EditorResult::Continue
+            }
+            KeyCode::Left | KeyCode::Up | KeyCode::BackTab => {
+                state.move_modal_choice(-1);
+                EditorResult::Continue
+            }
+            KeyCode::Right | KeyCode::Down | KeyCode::Tab => {
+                state.move_modal_choice(1);
+                EditorResult::Continue
+            }
+            KeyCode::Enter => state.activate_modal(),
+            _ => EditorResult::Continue,
+        };
+    }
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+        return state.request_save();
+    }
+    match key.code {
+        KeyCode::Tab => state.cycle_focus(false),
+        KeyCode::BackTab => state.cycle_focus(true),
+        KeyCode::Up
+            if state.mode == EditorMode::All
+                && matches!(state.focus, Focus::Search | Focus::List) =>
+        {
+            state.move_selection(-1)
+        }
+        KeyCode::Down
+            if state.mode == EditorMode::All
+                && matches!(state.focus, Focus::Search | Focus::List) =>
+        {
+            state.move_selection(1)
+        }
+        KeyCode::Up if state.mode == EditorMode::All && is_form_focus(state.focus) => {
+            move_form_focus(state, -1)
+        }
+        KeyCode::Down if state.mode == EditorMode::All && is_form_focus(state.focus) => {
+            move_form_focus(state, 1)
+        }
+        KeyCode::Right
+            if state.mode == EditorMode::All
+                && matches!(state.focus, Focus::Search | Focus::List) =>
+        {
+            state.compact_form = true;
+            state.focus = Focus::Name;
+        }
+        KeyCode::Left
+            if state.mode == EditorMode::All
+                && matches!(state.focus, Focus::Enabled | Focus::Global) =>
+        {
+            focus_catalog_list(state)
+        }
+        KeyCode::Left
+            if state.mode == EditorMode::All
+                && state.focus == Focus::Name
+                && state.selected().is_some_and(|draft| draft.name.cursor == 0) =>
+        {
+            focus_catalog_list(state)
+        }
+        KeyCode::Left if state.focus.is_text() => state.edit_focused(TextAction::Left),
+        KeyCode::Right if state.focus.is_text() => state.edit_focused(TextAction::Right),
+        KeyCode::Home if state.focus.is_text() => state.edit_focused(TextAction::Home),
+        KeyCode::End if state.focus.is_text() => state.edit_focused(TextAction::End),
+        KeyCode::Backspace if state.focus.is_text() => state.edit_focused(TextAction::Backspace),
+        KeyCode::Delete if state.focus.is_text() => state.edit_focused(TextAction::Delete),
+        KeyCode::Char(character)
+            if state.focus.is_text() && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            state.edit_focused(TextAction::Insert(character))
+        }
+        KeyCode::Char(' ') if matches!(state.focus, Focus::Enabled | Focus::Global) => {
+            state.toggle_focused()
+        }
+        KeyCode::Char('?') => state.modal = Some(Modal::Help),
+        KeyCode::Char('q') => return state.request_quit(),
+        KeyCode::Esc if state.mode == EditorMode::All && state.compact_form => {
+            state.compact_form = false;
+            state.focus = Focus::List;
+        }
+        KeyCode::Esc => return state.request_quit(),
+        KeyCode::Enter => return activate_focus(state),
+        _ => {}
+    }
+    EditorResult::Continue
+}
+
+fn is_form_focus(focus: Focus) -> bool {
+    matches!(
+        focus,
+        Focus::Name
+            | Focus::Command
+            | Focus::Description
+            | Focus::Tags
+            | Focus::Enabled
+            | Focus::Global
+    )
+}
+
+fn move_form_focus(state: &mut EditorState, delta: isize) {
+    let mut fields = vec![
+        Focus::Name,
+        Focus::Command,
+        Focus::Description,
+        Focus::Tags,
+        Focus::Enabled,
+    ];
+    if state.shell == ShellType::Zsh {
+        fields.push(Focus::Global);
+    }
+    let current = fields
+        .iter()
+        .position(|focus| *focus == state.focus)
+        .unwrap_or(0) as isize;
+    let next = (current + delta).clamp(0, fields.len() as isize - 1) as usize;
+    state.focus = fields[next];
+}
+
+fn focus_catalog_list(state: &mut EditorState) {
+    state.compact_form = false;
+    state.focus = Focus::List;
+}
+
+fn activate_focus(state: &mut EditorState) -> EditorResult {
+    match state.focus {
+        Focus::Enabled | Focus::Global => state.toggle_focused(),
+        Focus::Add => state.add_alias(),
+        Focus::Delete => state.request_delete(),
+        Focus::Save => return state.request_save(),
+        Focus::Cancel => return state.request_quit(),
+        Focus::List | Focus::Search if state.mode == EditorMode::All => {
+            state.compact_form = true;
+            state.focus = Focus::Name;
+        }
+        _ => {}
+    }
+    EditorResult::Continue
+}
+
+fn handle_mouse(state: &mut EditorState, mouse: MouseEvent, areas: &UiAreas) -> EditorResult {
+    match mouse.kind {
+        MouseEventKind::ScrollUp => {
+            state.move_selection(-1);
+            EditorResult::Continue
+        }
+        MouseEventKind::ScrollDown => {
+            state.move_selection(1);
+            EditorResult::Continue
+        }
+        MouseEventKind::Down(MouseButton::Left) => {
+            match areas.at(mouse.column, mouse.row) {
+                Some(MouseTarget::Alias(id)) => {
+                    state.select(id);
+                    if state.compact_layout {
+                        state.compact_form = true;
+                        state.focus = Focus::Name;
+                    } else {
+                        state.focus = Focus::List;
+                    }
+                }
+                Some(MouseTarget::Focus(focus)) => {
+                    state.focus = focus;
+                    if focus.is_text() {
+                        return EditorResult::Continue;
+                    }
+                    return activate_focus(state);
+                }
+                Some(MouseTarget::ModalChoice(choice)) => {
+                    state.set_modal_choice(choice);
+                    return state.activate_modal();
+                }
+                None => {}
+            }
+            EditorResult::Continue
+        }
+        _ => EditorResult::Continue,
+    }
+}
+
+fn render(frame: &mut Frame<'_>, state: &mut EditorState, areas: &mut UiAreas) {
+    let area = frame.area();
+    let block = Block::default()
+        .title(" aliasmgr interactive edit ")
+        .borders(Borders::ALL);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let rows = Layout::vertical([Constraint::Min(4), Constraint::Length(1)]).split(inner);
+    let compact = area.width < WIDE_LAYOUT_WIDTH || area.height < WIDE_LAYOUT_HEIGHT;
+    state.compact_layout = compact;
+    if state.mode == EditorMode::All && !(compact && state.compact_form) {
+        if compact {
+            render_catalog_list(frame, state, rows[0], areas);
+        } else {
+            let columns =
+                Layout::horizontal([Constraint::Percentage(34), Constraint::Percentage(66)])
+                    .split(rows[0]);
+            render_catalog_list(frame, state, columns[0], areas);
+            render_form(frame, state, columns[1], areas);
+        }
+    } else {
+        render_form(frame, state, rows[0], areas);
+    }
+    render_footer(frame, state, rows[1]);
+    if let Some(modal) = &state.modal {
+        render_modal(frame, modal, area, areas);
+    }
+}
+
+fn render_catalog_list(
+    frame: &mut Frame<'_>,
+    state: &EditorState,
+    area: Rect,
+    areas: &mut UiAreas,
+) {
+    let rows = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    render_input(
+        frame,
+        "Search all fields",
+        &state.search,
+        state.focus == Focus::Search,
+        rows[0],
+        Focus::Search,
+        areas,
+    );
+    let ids = state.filtered_ids();
+    let list_inner = Block::default().borders(Borders::ALL).inner(rows[1]);
+    let visible_count = list_inner.height as usize;
+    let selected_position = state
+        .selected_id
+        .and_then(|selected| ids.iter().position(|id| *id == selected))
+        .unwrap_or(0);
+    let start = selected_position.saturating_sub(visible_count.saturating_sub(1));
+    let visible_ids = ids
+        .iter()
+        .skip(start)
+        .take(visible_count)
+        .copied()
+        .collect::<Vec<_>>();
+    let items = visible_ids
+        .iter()
+        .filter_map(|id| state.drafts.iter().find(|draft| draft.id == *id))
+        .map(|draft| {
+            let marker = if Some(draft.id) == state.selected_id {
+                "› "
+            } else {
+                "  "
+            };
+            let item = ListItem::new(format!(
+                "{marker}{}",
+                if draft.name.value.is_empty() {
+                    "<new alias>"
+                } else {
+                    &draft.name.value
+                }
+            ));
+            if Some(draft.id) == state.selected_id {
+                item.style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )
+            } else {
+                item
+            }
+        })
+        .collect::<Vec<_>>();
+    let list = List::new(items)
+        .block(Block::default().title("Aliases").borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_widget(list, rows[1]);
+    for (offset, id) in visible_ids.into_iter().enumerate() {
+        areas.add(
+            Rect {
+                x: list_inner.x,
+                y: list_inner.y + offset as u16,
+                width: list_inner.width,
+                height: 1,
+            },
+            MouseTarget::Alias(id),
+        );
+    }
+    let actions = Rect {
+        x: rows[2].x,
+        y: rows[2].y,
+        width: rows[2].width,
+        height: 1,
+    };
+    frame.render_widget(
+        Line::from(vec![
+            button(" Add ", state.focus == Focus::Add),
+            Span::raw("  "),
+            button(" Delete ", state.focus == Focus::Delete),
+            Span::raw("  "),
+            save_button(
+                state.focus == Focus::Save,
+                state.validation_errors().is_empty(),
+            ),
+            Span::raw("  "),
+            button(" Cancel ", state.focus == Focus::Cancel),
+        ]),
+        actions,
+    );
+    let add_width = 5;
+    areas.add(
+        Rect {
+            width: add_width,
+            ..actions
+        },
+        MouseTarget::Focus(Focus::Add),
+    );
+    areas.add(
+        Rect {
+            x: actions.x + add_width + 2,
+            width: 8,
+            ..actions
+        },
+        MouseTarget::Focus(Focus::Delete),
+    );
+    areas.add(
+        Rect {
+            x: actions.x + 17,
+            width: 6,
+            ..actions
+        },
+        MouseTarget::Focus(Focus::Save),
+    );
+    areas.add(
+        Rect {
+            x: actions.x + 25,
+            width: 8,
+            ..actions
+        },
+        MouseTarget::Focus(Focus::Cancel),
+    );
+}
+
+fn render_form(frame: &mut Frame<'_>, state: &EditorState, area: Rect, areas: &mut UiAreas) {
+    let Some(draft) = state.selected() else {
+        let rows = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(area);
+        frame.render_widget(
+            Paragraph::new("No alias selected. Use Add to create one."),
+            rows[0],
+        );
+        frame.render_widget(
+            Line::from(vec![
+                save_button(
+                    state.focus == Focus::Save,
+                    state.validation_errors().is_empty(),
+                ),
+                Span::raw("  "),
+                button(" Cancel ", state.focus == Focus::Cancel),
+            ]),
+            rows[1],
+        );
+        areas.add(
+            Rect {
+                width: 6,
+                ..rows[1]
+            },
+            MouseTarget::Focus(Focus::Save),
+        );
+        areas.add(
+            Rect {
+                x: rows[1].x + 8,
+                width: 8,
+                ..rows[1]
+            },
+            MouseTarget::Focus(Focus::Cancel),
+        );
+        return;
+    };
+    if area.height < WIDE_LAYOUT_HEIGHT {
+        render_compact_form(frame, state, draft, area, areas);
+        return;
+    }
+    let global_rows = u16::from(state.shell == ShellType::Zsh);
+    let rows = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Length(3),
+        Constraint::Length(1 + global_rows),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    render_input(
+        frame,
+        "Name",
+        &draft.name,
+        state.focus == Focus::Name,
+        rows[0],
+        Focus::Name,
+        areas,
+    );
+    render_input(
+        frame,
+        "Command",
+        &draft.command,
+        state.focus == Focus::Command,
+        rows[1],
+        Focus::Command,
+        areas,
+    );
+    render_input(
+        frame,
+        "Description (optional)",
+        &draft.description,
+        state.focus == Focus::Description,
+        rows[2],
+        Focus::Description,
+        areas,
+    );
+    render_input(
+        frame,
+        "Tags (comma-separated)",
+        &draft.tags,
+        state.focus == Focus::Tags,
+        rows[3],
+        Focus::Tags,
+        areas,
+    );
+    let toggle_line = Line::from(vec![
+        button(
+            if draft.enabled {
+                " [x] Enabled "
+            } else {
+                " [ ] Enabled "
+            },
+            state.focus == Focus::Enabled,
+        ),
+        Span::raw("  "),
+        if state.shell == ShellType::Zsh {
+            button(
+                if draft.global {
+                    " [x] Global "
+                } else {
+                    " [ ] Global "
+                },
+                state.focus == Focus::Global,
+            )
+        } else {
+            Span::raw("")
+        },
+    ]);
+    frame.render_widget(toggle_line, rows[4]);
+    areas.add(
+        Rect {
+            width: 13.min(rows[4].width),
+            ..rows[4]
+        },
+        MouseTarget::Focus(Focus::Enabled),
+    );
+    if state.shell == ShellType::Zsh {
+        areas.add(
+            Rect {
+                x: rows[4].x + 15,
+                width: 12.min(rows[4].width.saturating_sub(15)),
+                ..rows[4]
+            },
+            MouseTarget::Focus(Focus::Global),
+        );
+    }
+    let actions = rows[6];
+    frame.render_widget(
+        Line::from(vec![
+            save_button(
+                state.focus == Focus::Save,
+                state.validation_errors().is_empty(),
+            ),
+            Span::raw("  "),
+            button(" Cancel ", state.focus == Focus::Cancel),
+        ]),
+        actions,
+    );
+    areas.add(
+        Rect {
+            width: 6,
+            ..actions
+        },
+        MouseTarget::Focus(Focus::Save),
+    );
+    areas.add(
+        Rect {
+            x: actions.x + 8,
+            width: 8,
+            ..actions
+        },
+        MouseTarget::Focus(Focus::Cancel),
+    );
+}
+
+fn render_compact_form(
+    frame: &mut Frame<'_>,
+    state: &EditorState,
+    draft: &model::AliasDraft,
+    area: Rect,
+    areas: &mut UiAreas,
+) {
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    render_compact_input(
+        frame,
+        "Name",
+        &draft.name,
+        state.focus == Focus::Name,
+        rows[0],
+        Focus::Name,
+        areas,
+    );
+    render_compact_input(
+        frame,
+        "Command",
+        &draft.command,
+        state.focus == Focus::Command,
+        rows[1],
+        Focus::Command,
+        areas,
+    );
+    render_compact_input(
+        frame,
+        "Description",
+        &draft.description,
+        state.focus == Focus::Description,
+        rows[2],
+        Focus::Description,
+        areas,
+    );
+    render_compact_input(
+        frame,
+        "Tags",
+        &draft.tags,
+        state.focus == Focus::Tags,
+        rows[3],
+        Focus::Tags,
+        areas,
+    );
+    frame.render_widget(
+        Line::from(vec![
+            button(
+                if draft.enabled {
+                    " [x] Enabled "
+                } else {
+                    " [ ] Enabled "
+                },
+                state.focus == Focus::Enabled,
+            ),
+            Span::raw("  "),
+            if state.shell == ShellType::Zsh {
+                button(
+                    if draft.global {
+                        " [x] Global "
+                    } else {
+                        " [ ] Global "
+                    },
+                    state.focus == Focus::Global,
+                )
+            } else {
+                Span::raw("")
+            },
+        ]),
+        rows[4],
+    );
+    areas.add(
+        Rect {
+            width: 13.min(rows[4].width),
+            ..rows[4]
+        },
+        MouseTarget::Focus(Focus::Enabled),
+    );
+    if state.shell == ShellType::Zsh {
+        areas.add(
+            Rect {
+                x: rows[4].x + 15,
+                width: 12.min(rows[4].width.saturating_sub(15)),
+                ..rows[4]
+            },
+            MouseTarget::Focus(Focus::Global),
+        );
+    }
+    frame.render_widget(
+        Line::from(vec![
+            save_button(
+                state.focus == Focus::Save,
+                state.validation_errors().is_empty(),
+            ),
+            Span::raw("  "),
+            button(" Cancel ", state.focus == Focus::Cancel),
+        ]),
+        rows[5],
+    );
+    areas.add(
+        Rect {
+            width: 6,
+            ..rows[5]
+        },
+        MouseTarget::Focus(Focus::Save),
+    );
+    areas.add(
+        Rect {
+            x: rows[5].x + 8,
+            width: 8,
+            ..rows[5]
+        },
+        MouseTarget::Focus(Focus::Cancel),
+    );
+}
+
+fn render_compact_input(
+    frame: &mut Frame<'_>,
+    label: &str,
+    field: &model::InputField,
+    focused: bool,
+    area: Rect,
+    focus: Focus,
+    areas: &mut UiAreas,
+) {
+    let marker = if focused { ">" } else { " " };
+    let prefix = format!("{marker} {label}: ");
+    let style = if focused {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let available = area.width.saturating_sub(prefix.width() as u16);
+    let (visible, cursor) = input_view(field, available);
+    frame.render_widget(
+        Line::from(vec![
+            Span::styled(prefix.clone(), style),
+            Span::raw(visible),
+        ]),
+        area,
+    );
+    areas.add(area, MouseTarget::Focus(focus));
+    if focused && available > 0 {
+        frame.set_cursor_position((area.x + prefix.width() as u16 + cursor, area.y));
+    }
+}
+
+fn render_input(
+    frame: &mut Frame<'_>,
+    title: &str,
+    field: &model::InputField,
+    focused: bool,
+    area: Rect,
+    focus: Focus,
+    areas: &mut UiAreas,
+) {
+    let border = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(border);
+    let inner = block.inner(area);
+    let (visible, cursor) = input_view(field, inner.width);
+    frame.render_widget(Paragraph::new(visible).block(block), area);
+    areas.add(area, MouseTarget::Focus(focus));
+    if focused && inner.width > 0 {
+        frame.set_cursor_position((inner.x + cursor, inner.y));
+    }
+}
+
+fn button(label: &'static str, focused: bool) -> Span<'static> {
+    let style = if focused {
+        Style::default()
+            .fg(Color::Black)
+            .bg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Cyan)
+    };
+    Span::styled(label, style)
+}
+
+fn save_button(focused: bool, valid: bool) -> Span<'static> {
+    if valid {
+        button(" Save ", focused)
+    } else {
+        Span::styled(" Save ", Style::default().fg(Color::DarkGray))
+    }
+}
+
+fn input_view(field: &model::InputField, width: u16) -> (String, u16) {
+    if width == 0 {
+        return (String::new(), 0);
+    }
+    let characters = field.value.chars().collect::<Vec<_>>();
+    let mut start = 0;
+    while start < field.cursor {
+        let prefix = characters[start..field.cursor].iter().collect::<String>();
+        if UnicodeWidthStr::width(prefix.as_str()) < width as usize {
+            break;
+        }
+        start += 1;
+    }
+    let visible = characters[start..].iter().collect::<String>();
+    let before_cursor = characters[start..field.cursor].iter().collect::<String>();
+    let cursor = UnicodeWidthStr::width(before_cursor.as_str()) as u16;
+    (visible, cursor.min(width - 1))
+}
+
+fn render_footer(frame: &mut Frame<'_>, state: &EditorState, area: Rect) {
+    let errors = state.validation_errors();
+    let message = errors
+        .first()
+        .map(String::as_str)
+        .or(state.status.as_deref())
+        .unwrap_or("Tab move  Space toggle  Ctrl-S save  ? help  q quit");
+    let style = if state.status.is_some() || !errors.is_empty() {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    frame.render_widget(
+        Paragraph::new(message)
+            .style(style)
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn render_modal(frame: &mut Frame<'_>, modal: &Modal, area: Rect, areas: &mut UiAreas) {
+    let width = area.width.saturating_sub(2).clamp(1, 64);
+    let height = match modal {
+        Modal::Help => 12,
+        _ => 7,
+    }
+    .min(area.height.saturating_sub(2));
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(width)) / 2,
+        y: area.y + (area.height.saturating_sub(height)) / 2,
+        width,
+        height,
+    };
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .title(" Confirm ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+    match modal {
+        Modal::Help => frame.render_widget(Paragraph::new("Tab / Shift-Tab  Move focus\nArrows             Navigate\nSpace              Toggle\nEnter              Activate\nCtrl-S             Save\nEsc                 Back or cancel\nq                   Quit\nMouse               Select and activate\n\nPress Esc to close help."), inner),
+        Modal::Replace { name, choice, .. } => render_choices(frame, inner, &format!("Replace existing alias '{name}'?"), &["Replace", "Keep editing"], *choice, areas),
+        Modal::Delete { name, choice, .. } => render_choices(frame, inner, &format!("Delete alias '{name}' from this draft?"), &["Delete", "Cancel"], *choice, areas),
+        Modal::DirtyExit { choice } => render_choices(frame, inner, "You have unsaved changes.", &["Save", "Discard", "Cancel"], *choice, areas),
+    }
+}
+
+fn render_choices(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    prompt: &str,
+    labels: &[&'static str],
+    choice: usize,
+    areas: &mut UiAreas,
+) {
+    let rows = Layout::vertical([Constraint::Min(2), Constraint::Length(1)]).split(area);
+    frame.render_widget(Paragraph::new(prompt).wrap(Wrap { trim: true }), rows[0]);
+    let mut spans = Vec::new();
+    let mut x = rows[1].x;
+    for (index, label) in labels.iter().enumerate() {
+        let text = format!(" {label} ");
+        let width = text.width() as u16;
+        spans.push(Span::styled(
+            text,
+            if index == choice {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Yellow)
+            },
+        ));
+        spans.push(Span::raw("  "));
+        areas.add(
+            Rect {
+                x,
+                y: rows[1].y,
+                width,
+                height: 1,
+            },
+            MouseTarget::ModalChoice(index),
+        );
+        x += width + 2;
+    }
+    frame.render_widget(Line::from(spans), rows[1]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::types::Alias;
+    use crossterm::event::KeyEventKind;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn catalog() -> AliasCatalog {
+        let mut catalog = AliasCatalog::new();
+        catalog
+            .aliases
+            .insert("ll".into(), Alias::new("ls -la".into(), true, false));
+        catalog
+    }
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new_with_kind(code, KeyModifiers::NONE, KeyEventKind::Press)
+    }
+    #[test]
+    fn automatic_height_preserves_terminal_history_space() {
+        assert_eq!(inline_height(9), None);
+        assert_eq!(inline_height(10), Some(9));
+        assert_eq!(inline_height(40), Some(22));
+        assert!(inline_height(24).unwrap() < 24);
+    }
+    #[test]
+    fn long_inputs_scroll_to_keep_the_cursor_visible() {
+        let field = model::InputField::new("0123456789".into());
+        let (visible, cursor) = input_view(&field, 5);
+        assert!(visible.starts_with("6789"));
+        assert_eq!(cursor, 4);
+    }
+    #[test]
+    fn keyboard_edits_toggles_and_opens_dirty_exit() {
+        let mut state = EditorState::single(&catalog(), "ll", ShellType::Zsh).unwrap();
+        state.focus = Focus::Command;
+        handle_key(&mut state, key(KeyCode::Char('!')));
+        state.focus = Focus::Enabled;
+        handle_key(&mut state, key(KeyCode::Char(' ')));
+        assert_eq!(state.selected().unwrap().command.value, "ls -la!");
+        assert!(!state.selected().unwrap().enabled);
+        handle_key(&mut state, key(KeyCode::Char('q')));
+        assert!(matches!(state.modal, Some(Modal::DirtyExit { .. })));
+    }
+    #[test]
+    fn all_mode_arrow_keys_navigate_list_form_and_text() {
+        let mut catalog = catalog();
+        catalog
+            .aliases
+            .insert("test".into(), Alias::new("true".into(), true, false));
+        let mut state = EditorState::all(&catalog, ShellType::Zsh);
+        state.focus = Focus::List;
+        let first = state.selected_id;
+
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_ne!(state.selected_id, first);
+        handle_key(&mut state, key(KeyCode::Right));
+        assert_eq!(state.focus, Focus::Name);
+        assert!(state.compact_form);
+
+        handle_key(&mut state, key(KeyCode::Down));
+        assert_eq!(state.focus, Focus::Command);
+        handle_key(&mut state, key(KeyCode::Home));
+        handle_key(&mut state, key(KeyCode::Right));
+        assert_eq!(state.selected().unwrap().command.cursor, 1);
+        handle_key(&mut state, key(KeyCode::Up));
+        assert_eq!(state.focus, Focus::Name);
+
+        handle_key(&mut state, key(KeyCode::Home));
+        handle_key(&mut state, key(KeyCode::Left));
+        assert_eq!(state.focus, Focus::List);
+        assert!(!state.compact_form);
+    }
+    #[test]
+    fn all_mode_left_from_toggle_returns_to_catalog_list() {
+        let mut state = EditorState::all(&catalog(), ShellType::Bash);
+        state.compact_form = true;
+        state.focus = Focus::Enabled;
+        handle_key(&mut state, key(KeyCode::Left));
+        assert_eq!(state.focus, Focus::List);
+        assert!(!state.compact_form);
+    }
+    #[test]
+    fn mouse_targets_select_and_activate_controls() {
+        let mut state = EditorState::single(&catalog(), "ll", ShellType::Zsh).unwrap();
+        let mut areas = UiAreas::default();
+        areas.add(Rect::new(2, 2, 5, 1), MouseTarget::Focus(Focus::Enabled));
+        let mouse = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 3,
+            row: 2,
+            modifiers: KeyModifiers::NONE,
+        };
+        handle_mouse(&mut state, mouse, &areas);
+        assert!(!state.selected().unwrap().enabled);
+    }
+    #[test]
+    fn wide_and_compact_layouts_render_without_full_screen() {
+        for (width, height) in [(100, 22), (50, 10)] {
+            let backend = TestBackend::new(width, height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            let mut state = EditorState::all(&catalog(), ShellType::Bash);
+            let mut areas = UiAreas::default();
+            terminal
+                .draw(|frame| render(frame, &mut state, &mut areas))
+                .unwrap();
+            assert!(!areas.0.is_empty());
+            state.compact_form = true;
+            terminal
+                .draw(|frame| render(frame, &mut state, &mut areas))
+                .unwrap();
+        }
+    }
+    #[test]
+    fn zsh_controls_and_every_modal_render_with_mouse_targets() {
+        let backend = TestBackend::new(100, 22);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut state = EditorState::single(&catalog(), "ll", ShellType::Zsh).unwrap();
+        let mut areas = UiAreas::default();
+        for modal in [
+            Modal::Help,
+            Modal::Replace {
+                source_id: 0,
+                target_id: None,
+                name: "other".into(),
+                choice: 1,
+            },
+            Modal::Delete {
+                id: 0,
+                name: "ll".into(),
+                choice: 1,
+            },
+            Modal::DirtyExit { choice: 2 },
+        ] {
+            state.modal = Some(modal);
+            terminal
+                .draw(|frame| render(frame, &mut state, &mut areas))
+                .unwrap();
+        }
+        assert!(
+            areas
+                .0
+                .iter()
+                .any(|(_, target)| *target == MouseTarget::Focus(Focus::Global))
+        );
+        assert!(
+            areas
+                .0
+                .iter()
+                .any(|(_, target)| matches!(target, MouseTarget::ModalChoice(_)))
+        );
+    }
+}

--- a/src/app/edit_tui/model.rs
+++ b/src/app/edit_tui/model.rs
@@ -1,0 +1,822 @@
+use std::collections::{BTreeSet, HashSet};
+
+use crate::app::shell::ShellType;
+use crate::catalog::types::{Alias, AliasCatalog};
+use crate::core::validation::{is_valid_alias_name, is_valid_tag};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditorMode {
+    Single,
+    All,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Focus {
+    Search,
+    List,
+    Name,
+    Command,
+    Description,
+    Tags,
+    Enabled,
+    Global,
+    Add,
+    Delete,
+    Save,
+    Cancel,
+}
+
+impl Focus {
+    pub fn is_text(self) -> bool {
+        matches!(
+            self,
+            Self::Search | Self::Name | Self::Command | Self::Description | Self::Tags
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InputField {
+    pub value: String,
+    pub cursor: usize,
+}
+
+impl InputField {
+    pub fn new(value: String) -> Self {
+        let cursor = value.chars().count();
+        Self { value, cursor }
+    }
+    pub fn insert(&mut self, character: char) {
+        let byte = byte_index(&self.value, self.cursor);
+        self.value.insert(byte, character);
+        self.cursor += 1;
+    }
+    pub fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let start = byte_index(&self.value, self.cursor - 1);
+        let end = byte_index(&self.value, self.cursor);
+        self.value.replace_range(start..end, "");
+        self.cursor -= 1;
+    }
+    pub fn delete(&mut self) {
+        if self.cursor == self.value.chars().count() {
+            return;
+        }
+        let start = byte_index(&self.value, self.cursor);
+        let end = byte_index(&self.value, self.cursor + 1);
+        self.value.replace_range(start..end, "");
+    }
+    pub fn move_left(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+    pub fn move_right(&mut self) {
+        self.cursor = (self.cursor + 1).min(self.value.chars().count());
+    }
+}
+
+fn byte_index(value: &str, character_index: usize) -> usize {
+    value
+        .char_indices()
+        .nth(character_index)
+        .map_or(value.len(), |(index, _)| index)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AliasDraft {
+    pub id: u64,
+    pub original_name: Option<String>,
+    pub name: InputField,
+    pub command: InputField,
+    pub description: InputField,
+    pub description_present: bool,
+    pub description_touched: bool,
+    pub tags: InputField,
+    pub enabled: bool,
+    pub global: bool,
+}
+
+impl AliasDraft {
+    fn from_alias(id: u64, name: &str, alias: &Alias) -> Self {
+        Self {
+            id,
+            original_name: Some(name.to_owned()),
+            name: InputField::new(name.to_owned()),
+            command: InputField::new(alias.command.clone()),
+            description: InputField::new(alias.description.clone().unwrap_or_default()),
+            description_present: alias.description.is_some(),
+            description_touched: false,
+            tags: InputField::new(alias.tags.iter().cloned().collect::<Vec<_>>().join(", ")),
+            enabled: alias.enabled,
+            global: alias.global,
+        }
+    }
+    fn empty(id: u64) -> Self {
+        Self {
+            id,
+            original_name: None,
+            name: InputField::new(String::new()),
+            command: InputField::new(String::new()),
+            description: InputField::new(String::new()),
+            description_present: false,
+            description_touched: false,
+            tags: InputField::new(String::new()),
+            enabled: true,
+            global: false,
+        }
+    }
+    pub fn parse(&self) -> Result<(String, Alias), Vec<String>> {
+        let mut errors = Vec::new();
+        if !is_valid_alias_name(&self.name.value) {
+            errors.push("Alias names cannot be empty or contain whitespace or '='.".to_owned());
+        }
+        if self.command.value.trim().is_empty() {
+            errors.push("Commands cannot be empty.".to_owned());
+        }
+        let tags = match parse_tags(&self.tags.value) {
+            Ok(tags) => tags,
+            Err(error) => {
+                errors.push(error);
+                BTreeSet::new()
+            }
+        };
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+        let description = if self.description.value.is_empty() {
+            (self.description_present && !self.description_touched).then(String::new)
+        } else {
+            Some(self.description.value.clone())
+        };
+        Ok((
+            self.name.value.clone(),
+            Alias {
+                command: self.command.value.clone(),
+                enabled: self.enabled,
+                global: self.global,
+                description,
+                tags,
+                detailed: false,
+            },
+        ))
+    }
+    fn searchable_text(&self) -> String {
+        format!(
+            "{}\n{}\n{}\n{}",
+            self.name.value, self.command.value, self.description.value, self.tags.value
+        )
+        .to_lowercase()
+    }
+}
+
+pub fn parse_tags(value: &str) -> Result<BTreeSet<String>, String> {
+    let tags = value
+        .split(',')
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty())
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    if let Some(tag) = tags.iter().find(|tag| !is_valid_tag(tag)) {
+        return Err(format!(
+            "Tag '{tag}' is invalid; tags cannot contain whitespace."
+        ));
+    }
+    Ok(tags)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Modal {
+    Replace {
+        source_id: u64,
+        target_id: Option<u64>,
+        name: String,
+        choice: usize,
+    },
+    Delete {
+        id: u64,
+        name: String,
+        choice: usize,
+    },
+    DirtyExit {
+        choice: usize,
+    },
+    Help,
+}
+
+impl Modal {
+    #[cfg(test)]
+    pub fn choice(&self) -> Option<usize> {
+        match self {
+            Self::Replace { choice, .. }
+            | Self::Delete { choice, .. }
+            | Self::DirtyExit { choice } => Some(*choice),
+            Self::Help => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EditorResult {
+    Continue,
+    ExitNoChanges,
+    Save(AliasCatalog),
+}
+
+pub struct EditorState {
+    pub mode: EditorMode,
+    pub shell: ShellType,
+    pub original: AliasCatalog,
+    pub drafts: Vec<AliasDraft>,
+    pub selected_id: Option<u64>,
+    pub search: InputField,
+    pub focus: Focus,
+    pub modal: Option<Modal>,
+    pub status: Option<String>,
+    pub compact_form: bool,
+    pub compact_layout: bool,
+    next_id: u64,
+    confirmed_external_replacements: HashSet<String>,
+    last_edited_id: Option<u64>,
+}
+
+impl EditorState {
+    pub fn single(catalog: &AliasCatalog, name: &str, shell: ShellType) -> Result<Self, String> {
+        let alias = catalog
+            .aliases
+            .get(name)
+            .ok_or_else(|| format!("Alias '{name}' does not exist."))?;
+        let draft = AliasDraft::from_alias(0, name, alias);
+        Ok(Self {
+            mode: EditorMode::Single,
+            shell,
+            original: catalog.clone(),
+            drafts: vec![draft],
+            selected_id: Some(0),
+            search: InputField::new(String::new()),
+            focus: Focus::Name,
+            modal: None,
+            status: None,
+            compact_form: true,
+            compact_layout: false,
+            next_id: 1,
+            confirmed_external_replacements: HashSet::new(),
+            last_edited_id: Some(0),
+        })
+    }
+    pub fn all(catalog: &AliasCatalog, shell: ShellType) -> Self {
+        let drafts = catalog
+            .aliases
+            .iter()
+            .enumerate()
+            .map(|(id, (name, alias))| AliasDraft::from_alias(id as u64, name, alias))
+            .collect::<Vec<_>>();
+        let selected_id = drafts.first().map(|draft| draft.id);
+        Self {
+            mode: EditorMode::All,
+            shell,
+            original: catalog.clone(),
+            next_id: drafts.len() as u64,
+            drafts,
+            selected_id,
+            search: InputField::new(String::new()),
+            focus: Focus::Search,
+            modal: None,
+            status: None,
+            compact_form: false,
+            compact_layout: false,
+            confirmed_external_replacements: HashSet::new(),
+            last_edited_id: selected_id,
+        }
+    }
+    pub fn selected(&self) -> Option<&AliasDraft> {
+        let id = self.selected_id?;
+        self.drafts.iter().find(|draft| draft.id == id)
+    }
+    pub fn selected_mut(&mut self) -> Option<&mut AliasDraft> {
+        let id = self.selected_id?;
+        self.drafts.iter_mut().find(|draft| draft.id == id)
+    }
+    pub fn filtered_ids(&self) -> Vec<u64> {
+        let query = self.search.value.to_lowercase();
+        self.drafts
+            .iter()
+            .filter(|draft| query.is_empty() || draft.searchable_text().contains(&query))
+            .map(|draft| draft.id)
+            .collect()
+    }
+    pub fn validation_errors(&self) -> Vec<String> {
+        self.drafts
+            .iter()
+            .flat_map(|draft| {
+                draft
+                    .parse()
+                    .err()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(move |error| {
+                        let name = if draft.name.value.is_empty() {
+                            "new alias"
+                        } else {
+                            &draft.name.value
+                        };
+                        format!("{name}: {error}")
+                    })
+            })
+            .collect()
+    }
+    pub fn is_dirty(&self) -> bool {
+        self.preview_catalog(false).map_or(true, |catalog| {
+            !semantic_catalog_eq(&catalog, &self.original)
+        })
+    }
+    pub fn add_alias(&mut self) {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.drafts.push(AliasDraft::empty(id));
+        self.selected_id = Some(id);
+        self.last_edited_id = Some(id);
+        self.focus = Focus::Name;
+        self.compact_form = true;
+        self.status = Some("New alias added to the draft.".to_owned());
+    }
+    pub fn request_delete(&mut self) {
+        let Some(draft) = self.selected() else {
+            self.status = Some("No alias is selected.".to_owned());
+            return;
+        };
+        self.modal = Some(Modal::Delete {
+            id: draft.id,
+            name: draft.name.value.clone(),
+            choice: 1,
+        });
+    }
+    pub fn request_quit(&mut self) -> EditorResult {
+        if self.is_dirty() {
+            self.modal = Some(Modal::DirtyExit { choice: 2 });
+            EditorResult::Continue
+        } else {
+            EditorResult::ExitNoChanges
+        }
+    }
+    pub fn request_save(&mut self) -> EditorResult {
+        self.status = None;
+        let errors = self.validation_errors();
+        if !errors.is_empty() {
+            self.status = Some(errors.join(" "));
+            return EditorResult::Continue;
+        }
+        if let Some((source_id, target_id, name)) = self.find_collision() {
+            self.modal = Some(Modal::Replace {
+                source_id,
+                target_id,
+                name,
+                choice: 1,
+            });
+            return EditorResult::Continue;
+        }
+        match self.preview_catalog(true) {
+            Ok(catalog) if semantic_catalog_eq(&catalog, &self.original) => {
+                EditorResult::ExitNoChanges
+            }
+            Ok(catalog) => EditorResult::Save(catalog),
+            Err(error) => {
+                self.status = Some(error);
+                EditorResult::Continue
+            }
+        }
+    }
+    fn find_collision(&self) -> Option<(u64, Option<u64>, String)> {
+        let source_id = self.last_edited_id.or(self.selected_id)?;
+        let source = self.drafts.iter().find(|draft| draft.id == source_id)?;
+        let name = source.name.value.clone();
+        if let Some(target) = self
+            .drafts
+            .iter()
+            .find(|draft| draft.id != source_id && draft.name.value == name)
+        {
+            return Some((source_id, Some(target.id), name));
+        }
+        if self.mode == EditorMode::Single
+            && source.original_name.as_deref() != Some(name.as_str())
+            && self.original.aliases.contains_key(&name)
+            && !self.confirmed_external_replacements.contains(&name)
+        {
+            return Some((source_id, None, name));
+        }
+        for (index, source) in self.drafts.iter().enumerate() {
+            if let Some(target) = self.drafts[..index]
+                .iter()
+                .find(|target| target.name.value == source.name.value)
+            {
+                return Some((source.id, Some(target.id), source.name.value.clone()));
+            }
+        }
+        None
+    }
+    fn preview_catalog(&self, _require_valid: bool) -> Result<AliasCatalog, String> {
+        let mut catalog = match self.mode {
+            EditorMode::Single => self.original.clone(),
+            EditorMode::All => AliasCatalog::new(),
+        };
+        if self.mode == EditorMode::Single
+            && let Some(original_name) = self
+                .drafts
+                .first()
+                .and_then(|draft| draft.original_name.as_ref())
+        {
+            catalog.aliases.remove(original_name);
+        }
+        for draft in &self.drafts {
+            let (name, alias) = draft.parse().map_err(|errors| errors.join(" "))?;
+            if self.confirmed_external_replacements.contains(&name) {
+                catalog.aliases.remove(&name);
+            }
+            catalog.aliases.insert(name, alias);
+        }
+        Ok(catalog)
+    }
+    pub fn move_selection(&mut self, delta: isize) {
+        let ids = self.filtered_ids();
+        if ids.is_empty() {
+            self.selected_id = None;
+            return;
+        }
+        let current = self
+            .selected_id
+            .and_then(|selected| ids.iter().position(|id| *id == selected))
+            .unwrap_or(0) as isize;
+        self.selected_id = Some(ids[(current + delta).clamp(0, ids.len() as isize - 1) as usize]);
+    }
+    pub fn select(&mut self, id: u64) {
+        if self.drafts.iter().any(|draft| draft.id == id) {
+            self.selected_id = Some(id);
+        }
+    }
+    pub fn cycle_focus(&mut self, backwards: bool) {
+        let focuses = self.focus_order();
+        let index = focuses
+            .iter()
+            .position(|focus| *focus == self.focus)
+            .unwrap_or(0);
+        let next = if backwards {
+            (index + focuses.len() - 1) % focuses.len()
+        } else {
+            (index + 1) % focuses.len()
+        };
+        self.focus = focuses[next];
+    }
+    fn focus_order(&self) -> Vec<Focus> {
+        if self.mode == EditorMode::All && self.compact_layout && !self.compact_form {
+            return vec![
+                Focus::Search,
+                Focus::List,
+                Focus::Add,
+                Focus::Delete,
+                Focus::Save,
+                Focus::Cancel,
+            ];
+        }
+        let mut fields = Vec::new();
+        if self.mode == EditorMode::All && !self.compact_layout {
+            fields.extend([Focus::Search, Focus::List]);
+        }
+        fields.extend([
+            Focus::Name,
+            Focus::Command,
+            Focus::Description,
+            Focus::Tags,
+            Focus::Enabled,
+        ]);
+        if self.shell == ShellType::Zsh {
+            fields.push(Focus::Global);
+        }
+        if self.mode == EditorMode::All && !self.compact_layout {
+            fields.extend([Focus::Add, Focus::Delete]);
+        }
+        fields.extend([Focus::Save, Focus::Cancel]);
+        fields
+    }
+    pub fn toggle_focused(&mut self) {
+        self.status = None;
+        let focus = self.focus;
+        let shell = self.shell.clone();
+        let Some(draft) = self.selected_mut() else {
+            return;
+        };
+        match focus {
+            Focus::Enabled => draft.enabled = !draft.enabled,
+            Focus::Global if shell == ShellType::Zsh => draft.global = !draft.global,
+            _ => return,
+        }
+        let id = draft.id;
+        self.last_edited_id = Some(id);
+    }
+    pub fn edit_focused(&mut self, action: TextAction) {
+        self.status = None;
+        let focus = self.focus;
+        let field = if focus == Focus::Search {
+            Some(&mut self.search)
+        } else {
+            self.selected_mut().and_then(|draft| match focus {
+                Focus::Name => Some(&mut draft.name),
+                Focus::Command => Some(&mut draft.command),
+                Focus::Description => {
+                    draft.description_touched = true;
+                    Some(&mut draft.description)
+                }
+                Focus::Tags => Some(&mut draft.tags),
+                _ => None,
+            })
+        };
+        let Some(field) = field else {
+            return;
+        };
+        match action {
+            TextAction::Insert(character) => field.insert(character),
+            TextAction::Backspace => field.backspace(),
+            TextAction::Delete => field.delete(),
+            TextAction::Left => field.move_left(),
+            TextAction::Right => field.move_right(),
+            TextAction::Home => field.cursor = 0,
+            TextAction::End => field.cursor = field.value.chars().count(),
+        }
+        if focus != Focus::Search {
+            self.last_edited_id = self.selected_id;
+            self.confirmed_external_replacements.clear();
+        } else {
+            self.selected_id = self.filtered_ids().first().copied();
+        }
+    }
+    pub fn move_modal_choice(&mut self, delta: isize) {
+        let Some(modal) = self.modal.as_mut() else {
+            return;
+        };
+        let (choice, count) = match modal {
+            Modal::Replace { choice, .. } | Modal::Delete { choice, .. } => (choice, 2),
+            Modal::DirtyExit { choice } => (choice, 3),
+            Modal::Help => return,
+        };
+        *choice = ((*choice as isize + delta).rem_euclid(count)) as usize;
+    }
+    pub fn set_modal_choice(&mut self, selected: usize) {
+        let Some(modal) = self.modal.as_mut() else {
+            return;
+        };
+        match modal {
+            Modal::Replace { choice, .. } | Modal::Delete { choice, .. } => {
+                *choice = selected.min(1)
+            }
+            Modal::DirtyExit { choice } => *choice = selected.min(2),
+            Modal::Help => {}
+        }
+    }
+    pub fn dismiss_modal(&mut self) {
+        self.modal = None;
+    }
+    pub fn activate_modal(&mut self) -> EditorResult {
+        let Some(modal) = self.modal.take() else {
+            return EditorResult::Continue;
+        };
+        match modal {
+            Modal::Replace {
+                source_id,
+                target_id,
+                name,
+                choice,
+            } => {
+                if choice == 0 {
+                    if let Some(target_id) = target_id {
+                        self.drafts.retain(|draft| draft.id != target_id);
+                    } else {
+                        self.confirmed_external_replacements.insert(name);
+                    }
+                    self.selected_id = Some(source_id);
+                    self.request_save()
+                } else {
+                    self.status = Some("Replacement declined; changes were not saved.".to_owned());
+                    EditorResult::Continue
+                }
+            }
+            Modal::Delete { id, choice, .. } => {
+                if choice == 0 {
+                    self.drafts.retain(|draft| draft.id != id);
+                    self.selected_id = self.filtered_ids().first().copied();
+                    self.status = Some("Alias removed from the draft.".to_owned());
+                }
+                EditorResult::Continue
+            }
+            Modal::DirtyExit { choice } => match choice {
+                0 => self.request_save(),
+                1 => EditorResult::ExitNoChanges,
+                _ => EditorResult::Continue,
+            },
+            Modal::Help => EditorResult::Continue,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TextAction {
+    Insert(char),
+    Backspace,
+    Delete,
+    Left,
+    Right,
+    Home,
+    End,
+}
+
+fn semantic_catalog_eq(left: &AliasCatalog, right: &AliasCatalog) -> bool {
+    left.aliases.len() == right.aliases.len()
+        && left.aliases.iter().all(|(name, alias)| {
+            right.aliases.get(name).is_some_and(|other| {
+                alias.command == other.command
+                    && alias.enabled == other.enabled
+                    && alias.global == other.global
+                    && alias.description == other.description
+                    && alias.tags == other.tags
+            })
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn catalog() -> AliasCatalog {
+        let mut catalog = AliasCatalog::new();
+        let mut ll = Alias::new("ls -la".into(), true, false);
+        ll.description = Some("List files".into());
+        ll.tags.extend(["files".into(), "shell".into()]);
+        catalog.aliases.insert("ll".into(), ll);
+        catalog
+            .aliases
+            .insert("test".into(), Alias::new("cargo test".into(), true, false));
+        catalog
+    }
+    #[test]
+    fn tags_are_trimmed_sorted_and_deduplicated() {
+        assert_eq!(
+            parse_tags("rust, dev, rust")
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            ["dev", "rust"]
+        );
+        assert!(parse_tags("two words").is_err());
+    }
+    #[test]
+    fn single_edit_can_rename_and_replace_after_confirmation() {
+        let catalog = catalog();
+        let mut state = EditorState::single(&catalog, "ll", ShellType::Zsh).unwrap();
+        state.selected_mut().unwrap().name = InputField::new("test".into());
+        state.last_edited_id = state.selected_id;
+        assert_eq!(state.request_save(), EditorResult::Continue);
+        assert!(matches!(state.modal, Some(Modal::Replace { .. })));
+        state.move_modal_choice(-1);
+        let EditorResult::Save(saved) = state.activate_modal() else {
+            panic!("replacement should save")
+        };
+        assert_eq!(saved.aliases.len(), 1);
+        assert_eq!(saved.aliases["test"].command, "ls -la");
+    }
+    #[test]
+    fn declined_replacement_stays_in_editor() {
+        let catalog = catalog();
+        let mut state = EditorState::single(&catalog, "ll", ShellType::Zsh).unwrap();
+        state.selected_mut().unwrap().name = InputField::new("test".into());
+        state.last_edited_id = state.selected_id;
+        state.request_save();
+        assert_eq!(state.activate_modal(), EditorResult::Continue);
+        assert_eq!(state.selected().unwrap().name.value, "test");
+        assert_eq!(state.original, catalog);
+    }
+    #[test]
+    fn full_editor_searches_every_displayed_text_field() {
+        let mut state = EditorState::all(&catalog(), ShellType::Bash);
+        for query in ["ll", "ls -la", "list files", "shell"] {
+            state.search = InputField::new(query.into());
+            assert_eq!(state.filtered_ids().len(), 1, "{query}");
+        }
+    }
+    #[test]
+    fn new_alias_defaults_and_confirmed_delete_are_in_memory_only() {
+        let catalog = catalog();
+        let mut state = EditorState::all(&catalog, ShellType::Bash);
+        state.add_alias();
+        let new = state.selected().unwrap();
+        assert!(new.enabled);
+        assert!(!new.global);
+        assert!(new.command.value.is_empty());
+        let original_id = state.drafts[0].id;
+        state.selected_id = Some(original_id);
+        state.request_delete();
+        state.move_modal_choice(-1);
+        assert_eq!(state.activate_modal(), EditorResult::Continue);
+        assert_eq!(state.drafts.len(), 2);
+        assert_eq!(state.original, catalog);
+    }
+    #[test]
+    fn dirty_exit_defaults_to_cancel_and_can_discard() {
+        let mut state = EditorState::single(&catalog(), "ll", ShellType::Bash).unwrap();
+        state.selected_mut().unwrap().command.insert('!');
+        assert_eq!(state.request_quit(), EditorResult::Continue);
+        assert_eq!(state.modal.as_ref().and_then(Modal::choice), Some(2));
+        assert_eq!(state.activate_modal(), EditorResult::Continue);
+        state.request_quit();
+        state.move_modal_choice(-1);
+        assert_eq!(state.activate_modal(), EditorResult::ExitNoChanges);
+    }
+    #[test]
+    fn bash_focus_order_hides_global_but_preserves_its_value() {
+        let mut catalog = catalog();
+        catalog.aliases.get_mut("ll").unwrap().global = true;
+        let mut state = EditorState::single(&catalog, "ll", ShellType::Bash).unwrap();
+        for _ in 0..12 {
+            assert_ne!(state.focus, Focus::Global);
+            state.cycle_focus(false);
+        }
+        assert!(matches!(state.request_save(), EditorResult::ExitNoChanges));
+    }
+    #[test]
+    fn invalid_name_command_and_tags_disable_saving() {
+        let mut state = EditorState::single(&catalog(), "ll", ShellType::Zsh).unwrap();
+        let draft = state.selected_mut().unwrap();
+        draft.name.value = "bad name".into();
+        draft.command.value.clear();
+        draft.tags.value = "bad tag".into();
+        assert_eq!(state.request_save(), EditorResult::Continue);
+        let status = state.status.unwrap();
+        assert!(status.contains("Alias names"));
+        assert!(status.contains("Commands"));
+        assert!(status.contains("Tag 'bad tag'"));
+    }
+    #[test]
+    fn full_editor_add_collision_replaces_only_after_confirmation() {
+        let mut state = EditorState::all(&catalog(), ShellType::Bash);
+        state.add_alias();
+        let draft = state.selected_mut().unwrap();
+        draft.name = InputField::new("ll".into());
+        draft.command = InputField::new("eza -la".into());
+        assert_eq!(state.request_save(), EditorResult::Continue);
+        assert!(matches!(state.modal, Some(Modal::Replace { .. })));
+        state.move_modal_choice(-1);
+        let EditorResult::Save(saved) = state.activate_modal() else {
+            panic!("accepted replacement should save")
+        };
+        assert_eq!(saved.aliases["ll"].command, "eza -la");
+        assert_eq!(saved.aliases.len(), 2);
+    }
+    #[test]
+    fn representation_only_differences_are_semantic_noops() {
+        let mut catalog = catalog();
+        catalog.aliases.get_mut("test").unwrap().detailed = true;
+        let mut state = EditorState::single(&catalog, "test", ShellType::Bash).unwrap();
+        assert!(!state.is_dirty());
+        assert!(matches!(state.request_save(), EditorResult::ExitNoChanges));
+    }
+    #[test]
+    fn compact_focus_cycle_only_visits_visible_view_controls() {
+        let mut state = EditorState::all(&catalog(), ShellType::Bash);
+        state.compact_layout = true;
+        state.compact_form = false;
+        for _ in 0..6 {
+            assert!(matches!(
+                state.focus,
+                Focus::Search
+                    | Focus::List
+                    | Focus::Add
+                    | Focus::Delete
+                    | Focus::Save
+                    | Focus::Cancel
+            ));
+            state.cycle_focus(false);
+        }
+        state.compact_form = true;
+        state.focus = Focus::Name;
+        for _ in 0..7 {
+            assert!(matches!(
+                state.focus,
+                Focus::Name
+                    | Focus::Command
+                    | Focus::Description
+                    | Focus::Tags
+                    | Focus::Enabled
+                    | Focus::Save
+                    | Focus::Cancel
+            ));
+            state.cycle_focus(false);
+        }
+    }
+    #[test]
+    fn unicode_input_cursor_edits_character_boundaries() {
+        let mut input = InputField::new("a🦀".into());
+        input.move_left();
+        input.insert('é');
+        assert_eq!(input.value, "aé🦀");
+        input.backspace();
+        assert_eq!(input.value, "a🦀");
+        input.delete();
+        assert_eq!(input.value, "a");
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod add;
 pub(crate) mod disable;
 pub(crate) mod doctor;
 pub(crate) mod edit;
+mod edit_tui;
 pub(crate) mod enable;
 pub(crate) mod file_path;
 pub(crate) mod import;

--- a/src/catalog/io.rs
+++ b/src/catalog/io.rs
@@ -1,7 +1,8 @@
 //! Load and save the alias catalog.
 
 use std::fs;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use log::{debug, info, warn};
@@ -77,11 +78,43 @@ pub fn save_catalog(catalog: &mut AliasCatalog, path: &PathBuf) -> Result<()> {
     if !path.exists() {
         warn!("alias catalog file {:?} does not exist, creating it", path);
     }
-    if let Some(parent) = path.parent() {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
         fs::create_dir_all(parent)?;
     }
     debug!("Saving catalog to {:?}", path);
-    fs::write(path, content).with_context(|| format!("could not save catalog '{}'", path.display()))
+    atomic_write(path, content.as_bytes())
+        .with_context(|| format!("could not save catalog '{}'", path.display()))
+}
+
+fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
+    let write_path =
+        if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+            fs::canonicalize(path)?
+        } else {
+            path.to_owned()
+        };
+    let parent = write_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let permissions = fs::metadata(&write_path)
+        .ok()
+        .map(|metadata| metadata.permissions());
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(content)?;
+    temporary.as_file_mut().sync_all()?;
+    if let Some(permissions) = permissions {
+        temporary.as_file().set_permissions(permissions)?;
+    }
+    temporary
+        .persist(&write_path)
+        .map_err(|error| error.error)?;
+    #[cfg(unix)]
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -214,5 +247,55 @@ mod tests {
     #[test]
     fn default_catalog_path_uses_aliasmgr_config_directory() {
         assert!(catalog_path(None).ends_with("aliasmgr/aliases.toml"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn catalog_replacement_is_atomic_and_preserves_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("aliases.toml");
+        fs::write(&path, "old = \"value\"\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640)).unwrap();
+        let mut catalog = AliasCatalog::new();
+        catalog
+            .aliases
+            .insert("new".into(), Alias::new("value".into(), true, false));
+
+        save_catalog(&mut catalog, &path).unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new = \"value\"\n");
+        assert_eq!(
+            fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640
+        );
+        assert_eq!(fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_save_preserves_a_catalog_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TempDir::new().unwrap();
+        let target = directory.path().join("managed.toml");
+        let link = directory.path().join("aliases.toml");
+        fs::write(&target, "old = \"value\"\n").unwrap();
+        symlink(&target, &link).unwrap();
+        let mut catalog = AliasCatalog::new();
+        catalog
+            .aliases
+            .insert("new".into(), Alias::new("value".into(), true, false));
+
+        save_catalog(&mut catalog, &link).unwrap();
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new = \"value\"\n");
     }
 }

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -5,10 +5,18 @@ use super::validate_tag;
 #[derive(Args)]
 pub struct EditCommand {
     /// Alias to edit
-    pub name: String,
+    pub name: Option<String>,
 
     /// Replacement command
     pub command: Option<String>,
+
+    /// Open the inline interactive editor
+    #[arg(short = 'i', long, conflicts_with_all = ["command", "add_tag", "remove_tag", "description", "clear_description", "global", "no_global"])]
+    pub interactive: bool,
+
+    /// Edit the complete alias catalog interactively
+    #[arg(long, requires = "interactive", conflicts_with = "name")]
+    pub all: bool,
 
     /// Add a tag; repeat to add multiple tags
     #[arg(short, long, value_name = "TAG", value_parser = validate_tag)]
@@ -37,7 +45,8 @@ pub struct EditCommand {
 
 impl EditCommand {
     pub fn has_changes(&self) -> bool {
-        self.command.is_some()
+        self.interactive
+            || self.command.is_some()
             || self.description.is_some()
             || self.clear_description
             || !self.add_tag.is_empty()
@@ -54,8 +63,10 @@ mod tests {
 
     fn command() -> EditCommand {
         EditCommand {
-            name: "test".into(),
+            name: Some("test".into()),
             command: None,
+            interactive: false,
+            all: false,
             description: None,
             clear_description: false,
             add_tag: vec![],

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -111,6 +111,22 @@ impl Cli {
                 "--no cannot be used with --replace-existing",
             ));
         }
+        if let Commands::Edit(cmd) = &self.command {
+            if cmd.interactive
+                && let Some(control) = controls.first()
+            {
+                return Err(Self::command().error(
+                    ErrorKind::ArgumentConflict,
+                    format!("{control} cannot be used with --interactive"),
+                ));
+            }
+            if cmd.name.is_none() && !cmd.all {
+                return Err(Self::command().error(
+                    ErrorKind::MissingRequiredArgument,
+                    "edit requires an alias name or --interactive --all",
+                ));
+            }
+        }
         if matches!(&self.command, Commands::Edit(cmd) if !cmd.has_changes()) {
             return Err(Self::command().error(
                 ErrorKind::MissingRequiredArgument,
@@ -144,7 +160,7 @@ pub enum Commands {
     /// Rename an alias or tag
     #[command(visible_alias = "rn")]
     Rename(RenameCommand),
-    /// Edit an alias command or metadata
+    /// Edit aliases directly or in an interactive terminal UI
     #[command(visible_alias = "ed")]
     Edit(EditCommand),
     /// Import aliases from Bash or Zsh files
@@ -212,6 +228,30 @@ mod tests {
     }
 
     #[test]
+    fn interactive_edit_supports_one_or_all_and_rejects_prompt_controls() {
+        for args in [
+            &["aliasmgr", "edit", "ll", "--interactive"][..],
+            &["aliasmgr", "edit", "--interactive", "--all"][..],
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            assert!(cli.validate_prompt_controls().is_ok(), "{args:?}");
+        }
+        for args in [
+            &["aliasmgr", "edit", "--interactive"][..],
+            &["aliasmgr", "edit", "ll", "--interactive", "command"][..],
+            &["aliasmgr", "edit", "ll", "--interactive", "--yes"][..],
+            &["aliasmgr", "edit", "ll", "--interactive", "--no"][..],
+            &["aliasmgr", "edit", "ll", "--interactive", "--no-input"][..],
+        ] {
+            let result = Cli::try_parse_from(args).and_then(|cli| {
+                cli.validate_prompt_controls()?;
+                Ok(cli)
+            });
+            assert!(result.is_err(), "{args:?}");
+        }
+    }
+
+    #[test]
     fn edit_rejects_removed_toggle_flags_and_conflicting_global_states() {
         for args in [
             &["aliasmgr", "edit", "ll", "--toggle-enabled"][..],
@@ -266,6 +306,8 @@ mod tests {
         assert_eq!(
             options(command.find_subcommand_mut("edit").unwrap(), "Options"),
             [
+                "interactive",
+                "all",
                 "add-tag",
                 "remove-tag",
                 "description",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,6 +22,7 @@ pub enum Failure {
     InvalidCatalog,
     InvalidPattern,
     InvalidColumns,
+    InteractiveEditor(String),
 }
 
 impl std::fmt::Display for Failure {
@@ -35,6 +36,7 @@ impl std::fmt::Display for Failure {
             Self::InvalidCatalog => "catalog is invalid",
             Self::InvalidPattern => "invalid glob pattern",
             Self::InvalidColumns => "list columns must not contain duplicates",
+            Self::InteractiveEditor(message) => message,
         };
         formatter.write_str(message)
     }
@@ -67,6 +69,10 @@ mod tests {
             (
                 Failure::InvalidColumns,
                 "list columns must not contain duplicates",
+            ),
+            (
+                Failure::InteractiveEditor("interactive editor failed".into()),
+                "interactive editor failed",
             ),
         ];
         for (failure, message) in cases {

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,11 +150,11 @@ fn main() {
             match outcome {
                 Outcome::NoChanges => debug!("No changes made to catalog or shell."),
                 Outcome::CatalogChanged => {
-                    if save_catalog(&mut catalog, &resolve_catalog_path(catalog_path.as_ref()))
-                        .is_err()
+                    if let Err(error) =
+                        save_catalog(&mut catalog, &resolve_catalog_path(catalog_path.as_ref()))
                     {
-                        eprintln!("Failed to save updated catalog.");
-                        return;
+                        eprintln!("ERROR: {error:#}");
+                        std::process::exit(1);
                     }
                     debug!("New catalog saved.");
                 }

--- a/tests/interactive_edit.rs
+++ b/tests/interactive_edit.rs
@@ -1,0 +1,48 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_aliasmgr(catalog: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_aliasmgr"))
+        .args(args)
+        .env("ALIASMGR_CATALOG_PATH", catalog)
+        .env("ALIASMGR_SHELL", "bash")
+        .output()
+        .unwrap()
+}
+
+#[test]
+fn interactive_edit_requires_a_terminal_without_rewriting_the_catalog() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    let original = "ll = \"ls -la\"\n";
+    fs::write(&catalog, original).unwrap();
+
+    for args in [
+        &["edit", "ll", "--interactive"][..],
+        &["edit", "--interactive", "--all"][..],
+    ] {
+        let output = run_aliasmgr(&catalog, args);
+        assert_eq!(output.status.code(), Some(1), "{args:?}: {output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("interactive editing requires a terminal")
+        );
+        assert_eq!(fs::read_to_string(&catalog).unwrap(), original);
+    }
+}
+
+#[test]
+fn interactive_edit_conflicts_with_every_global_prompt_control() {
+    let directory = tempfile::tempdir().unwrap();
+    let catalog = directory.path().join("aliases.toml");
+    fs::write(&catalog, "ll = \"ls -la\"\n").unwrap();
+
+    for control in ["--yes", "--no", "--no-input"] {
+        let output = run_aliasmgr(&catalog, &["edit", "ll", "--interactive", control]);
+        assert_eq!(output.status.code(), Some(2), "{control}: {output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("cannot be used with --interactive")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add an inline, auto-height terminal editor for one alias or the complete catalog
- support keyboard and mouse editing, search, add/delete, rename collision confirmation, dirty-exit choices, and Bash/Zsh-specific fields
- make all-mode arrow navigation move through aliases, switch between the catalog and form, and traverse form fields while preserving text cursor movement
- save accepted edits through the normal catalog serialization pipeline with atomic replacement, permission preservation, and symlink preservation
- reject interactive editing with global prompt-control flags and document the new workflows

## Validation

- cargo build --verbose
- cargo test --verbose (157 tests passed)
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- cargo llvm-cov --all-features --workspace --summary-only (93.74% line coverage)

Follow-up height configuration is tracked in #42.

Closes #25